### PR TITLE
feat: standardize workflows to match skill repo pattern

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,13 @@
+name: Auto-merge dependency PRs
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    uses: netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,52 @@
+name: Harness Verification
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-harness:
+    name: Verify Harness Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Verify AGENTS.md exists
+        run: |
+          if [ ! -f AGENTS.md ]; then
+            echo "::error::AGENTS.md is missing"
+            exit 1
+          fi
+
+      - name: Verify AGENTS.md is index format
+        run: |
+          LINES=$(wc -l < AGENTS.md)
+          if [ "$LINES" -gt 150 ]; then
+            echo "::error::AGENTS.md is too long ($LINES lines, max 150)"
+            exit 1
+          fi
+
+      - name: Verify AGENTS.md references
+        run: |
+          ERRORS=0
+          while IFS= read -r ref; do
+            [[ "$ref" == http* ]] && continue
+            [[ "$ref" == \#* ]] && continue
+            ref="${ref%%#*}"
+            ref="${ref%%\?*}"
+            if [ ! -e "$ref" ]; then
+              echo "::error file=AGENTS.md::Dead reference: $ref"
+              ERRORS=$((ERRORS + 1))
+            fi
+          done < <(grep -oP '\[.*?\]\(\K[^)]+' AGENTS.md 2>/dev/null || true)
+          exit $ERRORS
+
+      - name: Verify docs structure
+        run: |
+          if [ ! -f docs/ARCHITECTURE.md ]; then
+            echo "::warning::docs/ARCHITECTURE.md is missing"
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,30 +1,14 @@
 name: Lint
+
 on:
-  pull_request:
+  push:
     branches: [main]
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  markdown:
-    name: Markdown Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
-
-  yaml:
-    name: YAML Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: pip install yamllint
-      - run: yamllint -c .yamllint.yml .
-
-  shellcheck:
-    name: ShellCheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - run: shellcheck skills/agent-harness/scripts/verify-harness.sh
+  validate:
+    name: Skill Validation
+    uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,44 @@
+# .github/workflows/pr-quality.yml
+# Solo-maintainer auto-approve: approves PRs from repo collaborators
+# so that required_approving_review_count >= 1 is satisfied without
+# manual review for trusted authors.
+#
+# SECURITY: This workflow uses pull_request_target which runs with base branch
+# permissions. NEVER add an actions/checkout step here -- that would allow code
+# from the PR to execute with write access to the repository.
+
+name: PR Quality Gates
+
+on:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+
+jobs:
+    auto-approve:
+        name: Auto-approve (collaborators)
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
+              with:
+                  egress-policy: audit
+
+            - name: Check author permission
+              id: check-permission
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || echo "none")
+                  echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
+
+            - name: Auto-approve PR
+              if: steps.check-permission.outputs.permission == 'admin' || steps.check-permission.outputs.permission == 'write'
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh pr review --approve "$PR_URL"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Harness Skill
+
+Agent skill for bootstrapping, verifying, and enforcing agent-harness infrastructure in repositories.
+
+## Structure
+
+- `skills/agent-harness/SKILL.md` — Main skill definition (verify, bootstrap, audit modes)
+- `skills/agent-harness/checkpoints.yaml` — Mechanical and LLM checkpoints
+- `skills/agent-harness/scripts/verify-harness.sh` — Standalone verification script
+- `skills/agent-harness/references/` — Maturity levels, skill integration map, enforcement mechanisms
+- `docs/ARCHITECTURE.md` — Architecture overview
+
+## Commands
+
+- `make lint` — Run YAML, Markdown, and ShellCheck linting
+- `make test` — Run verification script against itself
+
+## Rules
+
+- AGENTS.md must be a compact index (<150 lines)
+- All file references in AGENTS.md must resolve
+- Checkpoints use the schema from `references/checkpoints-schema.md`
+- Quality delegation: harness verifies output of specialist skills, not the tools


### PR DESCRIPTION
## Summary

- Replace local `lint.yml` (direct action references causing Dependabot PRs) with reusable workflow from `skill-repo-skill`
- Add `pr-quality.yml` for solo-maintainer auto-approve
- Add `auto-merge-deps.yml` for Dependabot/Renovate auto-merge via reusable workflow
- Add `harness-verify.yml` for AGENTS.md consistency checks

Closes #5 (Dependabot action update no longer needed)

## Test plan
- [ ] Skill Validation passes via reusable workflow
- [ ] Harness Verification passes
- [ ] PR #5 can be closed