### PR TITLE
docs: add OpenAI harness operational patterns and agent-first architecture

### DIFF
--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -75,3 +75,5 @@ See `references/maturity-levels.md` for the full breakdown.
 - `references/agents-md-rules.md` -- AGENTS.md authoring rules and anti-patterns
 - `references/artefact-inventory.md` -- Complete list of harness artefacts with purposes
 - `references/delegation-map.md` -- Which skill handles which concern
+- `references/harness-engineering-overview.md` -- Theory: four system functions, operational patterns, anti-patterns
+- `references/agent-first-architecture.md` -- Application legibility, layered dependency model, agent-first technology choices

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -43,7 +43,7 @@ When artefacts are missing, create them from templates:
 | Makefile harness targets | `templates/Makefile.harness.tmpl` | All |
 | `scripts/verify-harness.sh` | `scripts/verify-harness.sh` (copy directly) | All |
 
-Populate templates with repo-specific values (project name, tech stack, existing conventions). Do not overwrite files that already exist without user confirmation.
+Populate with repo-specific values. Do not overwrite existing files without user confirmation.
 
 ### 3. Audit
 
@@ -54,10 +54,7 @@ Report the repo's maturity level (1, 2, or 3) and show what is needed to reach t
 - **AGENTS.md is an index, not an encyclopedia.** Keep it under 150 lines. Put detail in `docs/`.
 - **Enforcement is project-level.** CI workflows, git hooks, and branch protection enforce the harness -- not this skill at runtime.
 - **Verify first, bootstrap second.** Always run verification before creating artefacts. The skill checks artefacts, not tools.
-- **Delegate specialist work.** Route concerns to the appropriate skill:
-  - AGENTS.md content rules: `@agent-rules`
-  - Branch protection / merge checks setup: `@github-project` (GitHub) or manual GitLab settings
-  - Quality gates and CI pipelines: `@enterprise-readiness`
+- **Delegate specialist work.** See `references/delegation-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`).
 
 ## Maturity Levels
 

--- a/skills/agent-harness/references/agent-first-architecture.md
+++ b/skills/agent-harness/references/agent-first-architecture.md
@@ -1,0 +1,64 @@
+# Agent-First Architecture
+
+Design choices that make a repository legible and predictable for AI coding agents. These complement the four system functions (constrain, inform, verify, correct) by addressing what the agent sees when it runs the system, not just when it reads about it.
+
+Source: OpenAI Harness Engineering (<https://openai.com/index/harness-engineering/>).
+
+## Application Legibility
+
+For an agent to validate its own changes, it must be able to inspect the running system. Without this, the agent is flying blind and depends entirely on test-suite proxies for correctness.
+
+Three legibility primitives:
+
+- **Isolated runtime per worktree.** Every git worktree should be able to spin up an isolated instance of the product on a unique port/socket so the agent's branch and the agent's running system are tied together. Tools: ddev with project-scoped names, docker compose with project-name overrides, devcontainers per worktree.
+- **Visual inspection.** Agents inspect rendered output, not just code. Wire up Chrome DevTools Protocol or Playwright so the agent can request DOM snapshots and screenshots. Frontend changes that look correct in JSX may render broken; the harness should let the agent see that.
+- **Queryable observability.** Logs, metrics, and traces should be locally accessible to the agent in structured form. `docker compose logs --since=30s --no-color` is enough for many cases. Without observability, agents debug by intuition.
+
+These belong in the project's dev-environment scripts and Makefile/composer/npm targets, surfaced through AGENTS.md so the agent knows they exist.
+
+## Layered Dependency Model
+
+OpenAI enforces a strict layered architecture. Their canonical stack:
+
+```
+Types -> Config -> Repo -> Service -> Runtime -> UI
+```
+
+The specific layer names are not the point; the point is that the dependency graph is explicit, declared in code, and enforced by tooling. Agents do not absorb architecture from culture -- they follow rules that produce errors.
+
+Custom linters check imports against the layer rule -- a UI module cannot import directly from Runtime, a Service module cannot import from UI, and so on. When a violation occurs, the linter must produce an actionable error message aimed at the agent: name the file, name the rule, name the fix.
+
+Compare:
+
+- ❌ "Architectural violation in `component.tsx`"
+- ✅ "`component.tsx` (UI layer) imports from `src/runtime/cache.ts` (Runtime layer); UI must call Runtime through a Service. See `docs/ARCHITECTURE.md#layer-rules`."
+
+Recommended starting points for repos using this skill:
+
+1. Document the layer model in `docs/ARCHITECTURE.md` with a dependency diagram.
+2. Add a custom linter rule (eslint-plugin-boundaries, deptrac for PHP, or a small AST script) that enforces it.
+3. Make the rule a hard CI gate, not advisory.
+
+## Agent-First Technology Choices
+
+Prefer composable, boring technologies with stable APIs over cutting-edge libraries with opaque internals.
+
+Why: agents reason from context. A library with predictable, well-documented behaviour fits in the context window and yields correct code. A library that "does magic" forces the agent to either guess or re-read its source -- both of which fail at scale.
+
+Practical implications:
+
+- Use libraries with stable, well-documented APIs over those that change frequently or rely on convention-over-configuration.
+- When an external library proves consistently unpredictable for agents (mocks fail; generated code looks plausible but is wrong; the agent invents APIs that do not exist), consider reimplementing the slice you actually need in-repo. Repo code is fully legible to the agent; library code is not.
+- Boring beats clever for harnessed repos. The cost of a less-clever library is paid once; the cost of an opaque library is paid on every agent interaction.
+
+This is not a license to NIH everything. It is a deliberate trade-off: pay implementation cost once to get reliable agent behaviour forever after.
+
+## How These Relate to the Four Functions
+
+| Concept | Function | Where it lives |
+|---|---|---|
+| Application legibility | Inform + Verify | Dev-environment scripts, observability tooling, Makefile targets |
+| Layered dependency model | Constrain | `docs/ARCHITECTURE.md` + custom linter |
+| Boring technology choices | Constrain | Dependency policy in AGENTS.md, ADRs documenting reimplementation decisions |
+
+These reinforce one another: a layered architecture composed of opaque libraries is no architecture at all, and legibility without constraint just shows the agent more chaos.

--- a/skills/agent-harness/references/agent-first-architecture.md
+++ b/skills/agent-harness/references/agent-first-architecture.md
@@ -26,12 +26,14 @@ Types -> Config -> Repo -> Service -> Runtime -> UI
 
 The specific layer names are not the point; the point is that the dependency graph is explicit, declared in code, and enforced by tooling. Agents do not absorb architecture from culture -- they follow rules that produce errors.
 
-Custom linters check imports against the layer rule -- a UI module cannot import directly from Runtime, a Service module cannot import from UI, and so on. When a violation occurs, the linter must produce an actionable error message aimed at the agent: name the file, name the rule, name the fix.
+Read the diagram left-to-right as "depends only on the next layer to the left": UI depends on Runtime; Runtime depends on Service; Service depends on Repo; and so on. A UI module reaching past Runtime to import Service or Repo directly is a violation.
+
+Custom linters check imports against this rule. When a violation occurs, the linter must produce an actionable error message aimed at the agent: name the file, name the rule, name the fix.
 
 Compare:
 
 - ❌ "Architectural violation in `component.tsx`"
-- ✅ "`component.tsx` (UI layer) imports from `src/runtime/cache.ts` (Runtime layer); UI must call Runtime through a Service. See `docs/ARCHITECTURE.md#layer-rules`."
+- ✅ "`component.tsx` (UI layer) imports from `src/service/payments.ts` (Service layer); UI must access Service through the Runtime layer. See `docs/ARCHITECTURE.md#layer-rules`."
 
 Recommended starting points for repos using this skill:
 

--- a/skills/agent-harness/references/harness-engineering-overview.md
+++ b/skills/agent-harness/references/harness-engineering-overview.md
@@ -74,6 +74,37 @@ Across vendors and frameworks, several principles have converged:
 - The repo itself is the best place to store agent instructions. External configuration drifts.
 - Enforcement must work without the agent framework installed. Project-level mechanisms (CI, hooks, branch protection) outlive any specific tool.
 
+## Operational Patterns from OpenAI's Deployment
+
+OpenAI's five-month internal deployment (~1,500 PRs, ~1M LOC, team scaled 3 to 7 engineers) surfaced operational patterns that go beyond the four system functions. These describe how to *run* a harnessed repo day-to-day, not how to structure it.
+
+### Merge Philosophy: Minimal Blocking Gates
+
+Conventional code-review norms (two approvals, comprehensive manual QA, "every PR gets a comment") become bottlenecks once agents open dozens of PRs per day. OpenAI's stance:
+
+- Minimal blocking merge gates -- only mechanical checks block (tests, linting, harness verification). Subjective gates do not.
+- Short-lived pull requests -- merge fast, iterate via follow-up PRs.
+- Higher tolerance for quick post-merge corrections -- "the cost of a quick correction is low when the agent can implement it in minutes. The cost of blocking every merge on comprehensive upfront validation compounds across hundreds of concurrent tasks."
+
+This is consistent with the Level 3 stance that branch protection requires `harness-verify` to pass -- because that check is fast and mechanical. It is *not* consistent with stacking subjective approval gates, manual QA sign-off, or "minimum reviewer count" policies on top of an agent-driven workflow.
+
+### Continuous Entropy Management
+
+Treat pattern drift as a continuous background process, not a periodic sprint:
+
+- Define canonical patterns (logging format, naming conventions, component shape) as mechanical linter rules.
+- Run recurring background agents that scan for deviations and open auto-mergeable refactor PRs.
+- Treat technical debt as compound interest -- small continuous cleanup payments are far cheaper than waiting for a large refactor sprint.
+
+The opposite pattern -- batching cleanup into periodic "fix the AI slop" sessions -- is explicitly called out as inefficient. Continuous correction beats episodic correction.
+
+### Additional Anti-Patterns
+
+In addition to the anti-patterns covered earlier (monolithic instruction files, stale documentation), the article identifies two more:
+
+- **Unpredictable third-party dependencies.** Libraries with opaque internals or unstable APIs make agents unreliable because they cannot reason about behaviour. See `agent-first-architecture.md` for the agent-first technology trade-off.
+- **Periodic cleanup sprints.** Batching technical debt is more disruptive and more expensive than continuous background cleanup. See "Continuous entropy management" above.
+
 ## The Key Principle
 
 > "The model is commodity; the harness is moat."

--- a/skills/agent-harness/references/harness-engineering-overview.md
+++ b/skills/agent-harness/references/harness-engineering-overview.md
@@ -128,5 +128,6 @@ Runtime concerns (agent tracing, evaluation frameworks, durable execution, LLM o
 ## Sources
 
 - OpenAI Harness Engineering: <https://openai.com/index/harness-engineering/>
+- SWE Quiz commentary on the OpenAI writeup (source of the deployment metrics and operational-pattern framing in this doc): <https://www.swequiz.com/articles/openai-harness-engineering>
 - Anthropic Agent Development: <https://docs.anthropic.com/en/docs/build-with-claude/agentic-systems>
 - Claude Code SDK: <https://docs.claude.com/en/api/agent-sdk>


### PR DESCRIPTION
## Summary

Adds learnings from OpenAI's harness-engineering writeup that the existing `references/harness-engineering-overview.md` did not yet cover.

- Extends `harness-engineering-overview.md` with an **Operational Patterns** section: minimal-blocking merge gates with post-merge correction, continuous entropy management via background refactor agents, and two missing anti-patterns (unpredictable third-party deps, periodic cleanup sprints). Explicitly reconciles the merge-philosophy guidance with our existing Level 3 branch-protection stance.
- New `references/agent-first-architecture.md` covering three architectural principles: application legibility (worktree-isolated runtimes, visual inspection, queryable observability), layered dependency model with actionable linter-error examples, and agent-first technology choices (boring/stable APIs; reimplement opaque libs when reliability matters).
- Linked the new reference from `SKILL.md` alongside the existing overview.

Source: https://www.swequiz.com/articles/openai-harness-engineering (and the original https://openai.com/index/harness-engineering/ already cited in the overview).

Two atomic commits. Doc-only change. No checkpoints, templates, or scripts touched.

## Test plan

- [ ] verify-harness.sh shows "All references resolve" (verified locally before push)
- [ ] Reference docs render correctly on GitHub (tables, code blocks, headings)
- [ ] No broken links in the new file