### PR TITLE
fix: rewrite agent-harness checkpoints to satisfy assessment runner allowlist

### DIFF
--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -3,7 +3,7 @@ skill_id: agent-harness
 
 preconditions:
   - type: command
-    target: "git rev-parse --git-dir 2>/dev/null"
+    pattern: "git rev-parse --git-dir"
     desc: "Must be a git repository"
 
 mechanical:
@@ -16,7 +16,7 @@ mechanical:
 
   - id: AH-02
     type: command
-    target: "test $(wc -l < AGENTS.md) -lt 150"
+    pattern: "wc -l < AGENTS.md | awk '$1<150 {exit 0} {exit 1}'"
     severity: warning
     desc: "AGENTS.md is compact index (<150 lines)"
 
@@ -28,18 +28,22 @@ mechanical:
     desc: "AGENTS.md documents available commands"
 
   - id: AH-04
-    type: command
-    target: "test -d docs"
+    type: file_exists
+    target: docs
     severity: warning
     desc: "docs/ directory exists"
 
   # Level 2 — Verified
+  # Note: Comprehensive AGENTS.md reference resolution is performed by
+  # scripts/verify-harness.sh (run via the harness-verify CI workflow).
+  # The mechanical checkpoint here cannot loop with shell `for/while` under
+  # the assessment runner's command allowlist; it relies on `xargs test`
+  # over extracted markdown link targets, which catches local file refs
+  # but not anchor targets or templated URLs (those are validated upstream
+  # in verify-harness.sh).
   - id: AH-10
     type: command
-    target: >-
-      ! grep -oP '\\[.*?\\]\\(\\K[^)]+' AGENTS.md 2>/dev/null
-      | grep -v '^http' | grep -v '^#' | sed 's/[?#].*//'
-      | while read -r ref; do test -e "$ref" || { echo "Dead ref: $ref"; exit 1; }; done
+    pattern: "grep -oP '\\[.*?\\]\\(\\K[^)]+' AGENTS.md | grep -v '^http' | grep -v '^#' | sed 's/[?#].*//' | xargs -r -I {} test -e {}"
     severity: error
     desc: "All AGENTS.md references resolve to existing files"
 
@@ -51,22 +55,22 @@ mechanical:
 
   - id: AH-12
     type: command
-    target: "test -f .github/workflows/harness-verify.yml || (test -f .gitlab-ci.yml && grep -q 'harness-verify\\|verify-harness' .gitlab-ci.yml)"
+    pattern: "cat .github/workflows/harness-verify.yml .gitlab-ci.yml 2>/dev/null | grep -qE 'harness-verify|verify-harness'"
     severity: warning
     desc: "CI harness verification workflow exists (GitHub Actions or GitLab CI)"
 
   # Level 3 — Enforced
   - id: AH-20
-    type: command
-    target: "test -f .github/pull_request_template.md || test -d .github/PULL_REQUEST_TEMPLATE || test -n \"$(find .gitlab/merge_request_templates -maxdepth 1 -name '*.md' -print -quit 2>/dev/null)\""
+    type: file_exists
+    target: "{.github/pull_request_template.md,.github/PULL_REQUEST_TEMPLATE,.gitlab/merge_request_templates}"
     severity: warning
     desc: "PR/MR template with harness checklist exists"
 
   - id: AH-21
     type: command
-    target: "grep -qlr 'hooksPath\\|core.hookspath' .envrc .husky/husky.sh 2>/dev/null || grep -q 'post-install-cmd' composer.json 2>/dev/null"
+    pattern: "cat .envrc .husky/install.sh composer.json package.json 2>/dev/null | grep -qE 'hooksPath|core\\.hookspath|post-install-cmd|\"prepare\"'"
     severity: warning
-    desc: "Git hooks auto-activate on clone"
+    desc: "Git hooks auto-activate on clone (.envrc, .husky, or composer/npm install hook)"
 
   # === QUALITY DELEGATION ENFORCEMENT ===
   # The harness delegates quality to specialist skills but MUST verify
@@ -74,28 +78,26 @@ mechanical:
   # infrastructure exists and is properly configured.
 
   - id: AH-30
-    type: command
-    command: "test -f Build/Scripts/runTests.sh -o -f Makefile"
+    type: file_exists
+    target: "{Build/Scripts/runTests.sh,runTests.sh,Makefile}"
     severity: warning
     desc: "Test runner infrastructure must exist (runTests.sh or Makefile with test targets)"
 
   - id: AH-31
     type: command
-    command: "grep -hP '^\\s*level:\\s*(10|max|[89])' phpstan.neon Build/phpstan.neon 2>/dev/null | wc -l"
-    expected: "^[1-9]"
+    pattern: "grep -hP '^\\s*level:\\s*(10|max|[89])' phpstan.neon Build/phpstan.neon 2>/dev/null | wc -l | grep -qE '^[[:space:]]*[1-9]'"
     severity: warning
     desc: "PHPStan must be configured at level 8+ (PHP projects only; level 10 recommended)"
 
   - id: AH-32
-    type: command
-    command: "test -f captainhook.json || test -f .githooks/pre-commit || test -f .husky/pre-commit"
+    type: file_exists
+    target: "{captainhook.json,.githooks/pre-commit,.husky/pre-commit}"
     severity: warning
     desc: "Git hooks must be configured for pre-commit quality checks"
 
   - id: AH-33
     type: command
-    command: "find . -name '*_test.go' -o -name '*Test.php' -o -name '*.test.js' -o -name '*.test.ts' -o -name 'test_*.py' | head -1 | wc -l"
-    expected: "^[1-9]"
+    pattern: "find . -name '*_test.go' -o -name '*Test.php' -o -name '*.test.js' -o -name '*.test.ts' -o -name 'test_*.py' | head -1 | grep -q ."
     severity: error
     desc: "Project must have at least one test file (supports Go, PHP, JS, TS, Python)"
 


### PR DESCRIPTION
## Summary

The automated-assessment runner enforces a command allowlist (rejects \`;\`, \`&&\`, \`||\`, backticks, \`\$()\`, custom \`./<path>\` invocations). The previous \`skills/agent-harness/checkpoints.yaml\` used all of these — meaning the agent-harness skill was effectively **unverifiable** by /assess in practice. The precondition was silently failing (because the runner reads \`pattern:\` for type=command preconditions, not \`target:\`), and 6 mechanical checkpoints were being rejected as unsafe.

## Changes

| Checkpoint | Before | After |
|---|---|---|
| precondition | \`target: "git rev-parse --git-dir 2>/dev/null"\` | \`pattern: "git rev-parse --git-dir"\` |
| AH-02 | \`test \$(wc -l < AGENTS.md) -lt 150\` | \`wc -l < AGENTS.md \| awk '\$1<150 {exit 0} {exit 1}'\` |
| AH-04 | \`test -d docs\` | \`file_exists\` of \`docs\` |
| AH-10 | \`while read; test -e \|\| ... done\` | \`xargs -r -I {} test -e {}\` |
| AH-12 | \`test -f X \|\| (test -f Y && grep ...)\` | \`cat X Y 2>/dev/null \| grep -qE ...\` |
| AH-20 | \`test -f X \|\| test -d Y \|\| test -n \"\$(...)\"\` | \`file_exists\` with brace expansion |
| AH-21 | \`grep ... \|\| grep ...\` | \`cat ... \| grep -qE ...\` |
| AH-30 | \`test -f X -o -f Y\` | \`file_exists\` with brace expansion |
| AH-31 | command + ignored \`expected:\` field | command piped through \`grep -qE\` |
| AH-32 | \`test -f X \|\| test -f Y \|\| test -f Z\` | \`file_exists\` with brace expansion |
| AH-33 | command + ignored \`expected:\` field (passed vacuously) | command piped through \`grep -q .\` |

Also replaced two cases where the YAML used the \`expected:\` field, which the assessment runner silently ignores. AH-33 in particular was passing on every project regardless of whether test files actually exist.

## Verification

\`\`\`
$ bash /home/sme/.claude/skills/automated-assessment/scripts/run-checkpoints.sh \
    skills/agent-harness/checkpoints.yaml .

Skill: agent-harness
✓ [AH-01] AGENTS.md exists at repo root
✓ [AH-02] AGENTS.md is compact index (<150 lines)
✓ [AH-03] AGENTS.md documents available commands
✓ [AH-04] docs/ directory exists
✓ [AH-10] All AGENTS.md references resolve to existing files
✗ [AH-11] Architecture documentation exists - Not found: docs/ARCHITECTURE.md
✓ [AH-12] CI harness verification workflow exists
... (remaining failures are genuine repo gaps, not allowlist rejections)
\`\`\`

Before this PR, the precondition skipped the entire skill and 6 mechanical checks were \"Command rejected\". After: precondition runs cleanly, all 6 checks evaluate, real gaps surface.

## Test plan

- [ ] Skill-validation CI passes
- [ ] verify-harness.sh still passes (this change does not touch it)
- [ ] /assess agent-harness on this repo runs all checkpoints without rejection