### PR TITLE
fix(release): remove workflow_dispatch trigger and pull-requests: write per upstream SR-31 policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 jobs:
   release:
@@ -13,4 +12,3 @@ jobs:
       contents: write          # release upload
       id-token: write          # OIDC for sigstore (required by the attest job)
       attestations: write      # GitHub native attestation API (required by the attest job)
-      pull-requests: write     # required by checkpoint SR-31; see upstream issue for staleness


### PR DESCRIPTION
## Summary

Reverts the two lines added to `.github/workflows/release.yml` in PR #19.

PR #19 added `workflow_dispatch:` and `pull-requests: write` to satisfy stale
marketplace-cached SR-30/SR-31 checkpoints that were demanding them. The
upstream source skill `skill-repo-skill` has since reversed that policy in
its PR #87 (commit `5eb8071`, merged):

- The new SR-31 explicitly **forbids** `workflow_dispatch:` in `release.yml`
  because manual dispatch on the wrapper would re-introduce the unsigned-tag
  bug the policy is designed to prevent.
- The `pull-requests: write` permission was removed because the bump-job that
  required it was removed from the upstream reusable workflow.

Our local `release.yml` therefore now violates the current authoritative
upstream contract. This PR brings us back into conformance.

## Changes

- Remove `  workflow_dispatch:` line under `on:`
- Remove `      pull-requests: write` permission line and its trailing comment

## Test plan

- [ ] CI green on this PR
- [ ] Reusable upstream `release.yml` still callable by tag-push (no behavior
      change for the only supported trigger path)
- [ ] No future tag release relies on the removed `workflow_dispatch` or
      `pull-requests: write` permission