### PR TITLE
fix(checkpoints): address PR #20 follow-up review (AH-02 missing-file, AH-31 simplification, AH-21 Husky paths)

### DIFF
--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -16,7 +16,7 @@ mechanical:
 
   - id: AH-02
     type: command
-    pattern: "wc -l < AGENTS.md | awk '$1<150 {exit 0} {exit 1}'"
+    pattern: "awk 'END {exit !(NR<150)}' AGENTS.md"
     severity: warning
     desc: "AGENTS.md is compact index (<150 lines)"
 

--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -85,7 +85,7 @@ mechanical:
 
   - id: AH-31
     type: command
-    pattern: "grep -hP '^\\s*level:\\s*(10|max|[89])' phpstan.neon Build/phpstan.neon 2>/dev/null | wc -l | grep -qE '^[[:space:]]*[1-9]'"
+    pattern: "grep -hP '^\\s*level:\\s*(10|max|[89])' phpstan.neon Build/phpstan.neon 2>/dev/null | grep -q ."
     severity: warning
     desc: "PHPStan must be configured at level 8+ (PHP projects only; level 10 recommended)"
 

--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -68,7 +68,7 @@ mechanical:
 
   - id: AH-21
     type: command
-    pattern: "cat .envrc .husky/install.sh composer.json package.json 2>/dev/null | grep -qE 'hooksPath|core\\.hookspath|post-install-cmd|\"prepare\"'"
+    pattern: "cat .envrc .husky/install.sh .husky/husky.sh .husky/_/husky.sh composer.json package.json 2>/dev/null | grep -qE 'hooksPath|core\\.hookspath|post-install-cmd|\"prepare\"'"
     severity: warning
     desc: "Git hooks auto-activate on clone (.envrc, .husky, or composer/npm install hook)"
 


### PR DESCRIPTION
Follow-up to [PR #20](https://github.com/netresearch/agent-harness-skill/pull/20) (merged), addressing three substantive review threads that were left unresolved when that PR was merged.

## Summary

Three independent fixes to `skills/agent-harness/checkpoints.yaml`, one commit each.

### 1. AH-02 — false-pass when AGENTS.md is missing

[Gemini comment](https://github.com/netresearch/agent-harness-skill/pull/20#discussion_r3181957809) flagged that `wc -l < AGENTS.md | awk '$1<150 {exit 0} {exit 1}'` exits `0` when `AGENTS.md` does not exist: the `<` redirect fails but the pipe still flows, awk receives empty input, and its default END action exits 0. Result: the checkpoint silently passes for repos with no `AGENTS.md`.

Switched to `awk 'END {exit !(NR<150)}' AGENTS.md`. awk reads the file directly, so it errors out (non-zero exit) on a missing file. NR<150 is the only path that yields exit 0.

Verified locally:
- Old pattern in empty dir: `exit=0` (vacuous pass — bug)
- New pattern in empty dir: `exit=2` (correct fail)
- Both patterns in this repo (AGENTS.md is 23 lines): pass

### 2. AH-31 — simplify PHPStan-level check

[Gemini comment](https://github.com/netresearch/agent-harness-skill/pull/20#discussion_r3181957818) noted the trailer `wc -l | grep -qE '^[[:space:]]*[1-9]'` is an overcomplicated way of asking "did the upstream grep produce any output?". The first `grep -hP ...` already exits 0 on match, 1 on no match, so a trailing `grep -q .` is the direct equivalent. Same pass/fail semantics, fewer pipe stages.

### 3. AH-21 — Husky path coverage regression

[Copilot comment](https://github.com/netresearch/agent-harness-skill/pull/20#discussion_r3181978281) flagged that the PR #20 rewrite narrowed the Husky scan to only `.husky/install.sh`, dropping two paths real repos use:
- `.husky/husky.sh` — legacy v4-v8 helper sourced by hooks
- `.husky/_/husky.sh` — Husky v9+ generated helper

Repos using either path regressed to a false-fail on AH-21 even though git hooks auto-activate correctly. Both paths added back to the `cat` argument list.

## Allowlist compliance

All three patterns clear the assessment runner's restrictions:
- `cmd_base` is `awk`, `grep`, or `cat` — all allowlisted
- No `;`, `&&`, `||`, backtick, or `$(` chaining
- No `..` path traversal
- No `./X` tokens (no `./vendor/bin/` exception needed)

The single-quoted awk script `'END {exit !(NR<150)}'` contains `!(` which is distinct from the rejected `$(` substring.

## Verification

```
$ bash skills/agent-harness/scripts/verify-harness.sh --format=text
Summary: Level 1 PARTIAL | 1 error(s), 1 warning(s)
(unchanged from main)

$ bash run-checkpoints.sh skills/agent-harness/checkpoints.yaml .
Summary: 6 passed, 9 failed, 0 skipped
(no "Command rejected" entries; failures are legitimate — this skill repo is
 not a PHP/test project, so AH-11/20/21/30/31/32/33/34/35 fail as expected)
```

## Test plan

- [x] `verify-harness.sh` still passes the same set as before
- [x] `run-checkpoints.sh` produces no "Command rejected" entries
- [x] AH-02 fails on a fresh empty dir (no AGENTS.md) — confirmed
- [x] AH-02 passes on this repo (AGENTS.md = 23 lines) — confirmed
- [x] AH-31 still passes/fails on the same input as before — semantics preserved
- [x] AH-21 still picks up the original four signals — only adds two paths
- [ ] CI green on the follow-up PR