### PR TITLE
feat: retro-skill spec + harness integration (AH-22, AH-23)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- Brief description of changes -->
+
+## Checklist
+
+- [ ] AGENTS.md updated (if commands or repo structure changed)
+- [ ] docs/ updated (if architecture or design changed)
+- [ ] New subsystems/directories documented
+- [ ] Exec plan created in `docs/exec-plans/active/` (if multi-file change)
+
+## Retro
+
+<!-- Did this change reveal a reusable pattern, missing rule, or skill instruction gap? -->
+<!-- If yes, route via `/retro` to the correct destination (user-memory, project-rule, skill PR, checkpoint, harness-artefact). -->
+
+- [ ] Reusable pattern detected? (N/A if purely local fix)
+
+## Test Plan
+
+<!-- How to verify these changes work -->

--- a/docs/plans/2026-05-11-retro-skill.md
+++ b/docs/plans/2026-05-11-retro-skill.md
@@ -1,0 +1,135 @@
+# Plan: retro-skill Implementation
+
+| | |
+|---|---|
+| **Spec** | [`docs/specs/retro-skill.md`](../specs/retro-skill.md) |
+| **Status** | Phase 2 (PLAN) — for review |
+| **Date** | 2026-05-11 |
+
+## Component Map
+
+5 repos, 6 logical components.
+
+| # | Component | Repo | Type | Depends on |
+|---|---|---|---|---|
+| C1 | feedback-memory schema reference | `agent-rules-skill` | Contract doc | none |
+| C2 | materialization contract (skill PRs) | `skill-repo-skill` | Contract doc | none |
+| C3 | learning-derived checkpoints reference | `automated-assessment-skill` | Contract doc | none |
+| C4 | `retro-skill` repo + content | `netresearch/retro-skill` (NEW) | Skill repo | C1, C2, C3 |
+| C5 | Harness integration edits | `agent-harness-skill` | SKILL/refs/templates/checkpoints | C4 (for refs to work) |
+| C6 | Cross-repo smoke test | (any clean test repo) | Manual verification | C1–C5 |
+
+## Implementation Order
+
+```
+Phase 2.A (parallel — contract docs in companion repos)
+├── C1: agent-rules-skill / feedback-memory-schema.md
+├── C2: skill-repo-skill / materialization-contract.md + issue template + PR block
+└── C3: automated-assessment-skill / learning-derived-checkpoints.md
+    
+   ↓  Gate: 3 PRs open with stable doc structure (text can iterate)
+
+Phase 2.B (sequential — retro-skill build)
+├── B1: Repo creation on github.com/netresearch + local worktree under ~/p/
+├── B2: skill-repo-skill scaffolding (plugin.json, composer.json, licenses, README stub)
+├── B3: references/ directory (7 files; can be drafted in parallel, committed atomically)
+├── B4: scripts/detect-mechanical.py (Schicht A — testable)
+├── B5: scripts/find-installed-skills.sh (mechanical discovery helper)
+├── B6: scripts/extract-coach-events.py + scan-cross-session.py (Schicht C)
+├── B7: skills/retro/SKILL.md (frontmatter, triggers, workflow summary)
+├── B8: commands/retro.md (slash command definition)
+├── B9: hooks/session-end.json (off by default)
+├── B10: skills/retro/checkpoints.yaml (own quality gates)
+└── B11: docs/specs/retro-skill.md mirror
+
+   ↓  Gate: retro-skill runs end-to-end with stub classification
+
+Phase 2.C (sequential — harness integration in agent-harness-skill)
+├── C5.1: SKILL.md edits (Key Principle + Delegation)
+├── C5.2: references/skill-integration-map.md retro section
+├── C5.3: references/harness-engineering-overview.md addendum
+├── C5.4: templates/{pull_request,merge_request}_template.md.tmpl retro question
+└── C5.5: checkpoints.yaml AH-22 + AH-23
+    
+   ↓  Gate: AH-22 + AH-23 green against test repo with retro-skill installed
+
+Phase 2.D (smoke test + integration)
+├── D1: Test session against real Coach data (1011 candidates available)
+├── D2: Token budget measurement vs Coach-continuous-hooks baseline
+├── D3: Materialization smoke per destination (6×)
+├── D4: Private-repo confirmation path
+└── D5: Documentation: README with quickstart, link from agent-harness-skill
+```
+
+## Rationale for Order
+
+- **Contracts first (Phase A)** because retro-skill references them. Stub structure can be merged early; prose iterates.
+- **retro-skill before harness (Phase B vs C)** because harness verifies retro-skill artefacts exist. Reverse order would create false-negative checkpoints.
+- **Parallelism is highest in Phase A** (3 independent contract docs). Phase B is mostly sequential within retro-skill, but B3 (references/) is itself parallelizable across 7 files — subagent-dispatchable.
+- **Phase D after C** because end-to-end smoke needs harness checks active.
+
+## Risk Table
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | GitHub repo creation requires explicit user action | High | Low | User triggers `gh repo create netresearch/retro-skill` before B1; document in plan as prerequisite |
+| R2 | Skill-discovery keyword match produces false positives | Medium | Medium | Ask user on ambiguity; log decisions; cache per session |
+| R3 | Token budget unknown without prototype | Medium | Medium | Run early measurement after B7+B8; gate further work if >2× Coach baseline |
+| R4 | Coach `events.sqlite` schema undocumented | Low | Low | Read-only, graceful degrade if schema differs; explicit fallback to JSONL scan |
+| R5 | Patch worktree dirty-check produces false fallback to /tmp | Low | Low | Show user reason for fallback; allow override |
+| R6 | Companion PRs merged out of order (retro references stub) | Medium | Low | All contract PRs land first; retro-skill v0.1 release blocked on companion merges |
+| R7 | Private repo confirmation becomes UX friction | Medium | Medium | Remember per-repo decision per session; option to disable globally |
+| R8 | LLM cost spikes on long sessions | Medium | Medium | Hard cap on transcript bytes fed to LLM; truncate with summary |
+| R9 | Plugin manifest formats vary across plugins | Medium | Low | Try multiple sources (plugin.json, composer.json, git remote); fall back to user prompt |
+| R10 | Existing 8 `feedback_*.md` files don't all match documented schema | Low | Low | Verify schema match in B3 (feedback-memory-schema.md draft); align doc to reality |
+
+## Verification Gates
+
+| Gate | When | What to verify | Pass = |
+|---|---|---|---|
+| **G0 → A** | Before Phase A | Spec is approved | User explicit OK |
+| **A → B** | After Phase A | 3 contract docs merged or merge-ready | `gh pr list` shows 3 open/merged across companion repos with stable section structure |
+| **B7 measurement** | After B7+B8 | Token cost of `/retro` against synthetic session | Cost ≤ target (TBD after first measurement, document floor) |
+| **B → C** | After Phase B | retro-skill runs end-to-end with stub classification | `/retro` against test session produces ≥1 proposal of each destination type |
+| **C → D** | After Phase C | AH-22 + AH-23 trigger correctly | Harness verify in test repo shows AH-22 warning if template missing retro question; AH-23 info if hook present |
+| **D → release** | After Phase D | Smoke test passes for 6 destinations | One materialization per destination created in test repo; PRs land in source repos (not cache) |
+
+## Prerequisites Before Phase A
+
+User actions required (cannot be automated):
+
+- [ ] **Create empty GitHub repo:** `gh repo create netresearch/retro-skill --public --description "LLM-driven session retrospection skill"` (or via web UI)
+- [ ] **Approve this plan** (this document)
+- [ ] **Confirm AH-22 / AH-23 IDs** are still free (re-check `checkpoints.yaml` for collisions)
+- [ ] **Decide token budget target** for G3 verification (can be deferred; current placeholder is "dramatically below Coach baseline")
+
+## Estimation
+
+Approximations only — refine after Phase 3 (TASKS) decomposition.
+
+| Phase | Subagents possible | Sequential elapsed | Notes |
+|---|---|---|---|
+| A | 3 parallel | ~1 hour | Three contract docs, modest prose |
+| B | 7+ parallel (B3, scripts) | ~3 hours | retro-skill is the bulk; B4+B6 are Python with logic |
+| C | 1 sequential | ~30 min | Mostly editing existing files |
+| D | Manual | ~1 hour | Real session + 6 materialization smoke tests |
+| **Total** | | ~5.5 hours focused work | excludes review cycles and PR roundtrips |
+
+## Out of Plan (Out of Spec already, but reiterate)
+
+- Coach pipeline cleanup of 1011 stale candidates
+- Marketplace listing automation for retro-skill itself
+- Migration of existing 8 `feedback_*.md` to a new format (current format is canonical)
+- Multi-session UI / dashboard
+- Auto-merge of `/retro`-created PRs
+
+## What's Next
+
+1. **Review** this plan
+2. **Approve** prerequisites checklist above
+3. Proceed to **Phase 3 (TASKS)** — per-repo file-level tasks with:
+   - Acceptance criteria
+   - Verify command
+   - Files touched
+   - One task = one file change (per user preference)
+4. **Phase 4 (IMPLEMENT)** with subagent dispatch per task

--- a/docs/specs/retro-skill.md
+++ b/docs/specs/retro-skill.md
@@ -1,0 +1,516 @@
+# Spec: `retro-skill` — LLM-driven Session Retrospection
+
+| | |
+|---|---|
+| **Status** | Draft (Phase 1 — for review) |
+| **Owner Repo** | `agent-harness-skill` (this spec) |
+| **Implementation Repo** | `netresearch/retro-skill` (new, to be created) |
+| **Companion Changes** | 4 existing skill repos (small edits) |
+| **Author** | Sebastian Mendel |
+| **Date** | 2026-05-11 |
+
+## Objective
+
+Provide LLM-driven session retrospection as a reusable skill (`/retro`). Detect friction directly from the session transcript, classify into 6 destinations, materialize with per-proposal user approval. Replace the unused Coach approval pipeline with a single efficient pass.
+
+## Anlass (Why Now)
+
+Field investigation of the user's own workflow (subagent report, session 2026-05-11):
+
+- **Coach pipeline is write-only** — `~/.claude-coach/candidates.json` holds 1011 pending / 0 approved / 0 rejected. The hooks-driven detection pipeline (35 MB `events.sqlite`) produces noise (35× duplicates of "Correct syntax for gh pr" with different fingerprints due to flag reordering).
+- **The user does skill improvement manually and well**, but no reusable skill captures that workflow — team members cannot reproduce it.
+- **An LLM with the actual session transcript** is more accurate and more efficient than continuous regex-based hook detection.
+- **Existing canonical artefact:** `~/.claude/projects/-home-sme-p/memory/feedback_<slug>.md` (8 files, consistent schema). The materialization format already exists; the workflow that produces it is what's missing.
+
+## Scope
+
+| | |
+|---|---|
+| **NEW** | `netresearch/retro-skill` — own repo, own marketplace entry |
+| **EDIT (small)** | 4 repos for materialization conventions: `agent-harness-skill`, `agent-rules-skill`, `skill-repo-skill`, `automated-assessment-skill` |
+| **NO CHANGE** | `claude-coach-plugin` — Coach stays as-is, optionally read by retro-skill as a data source |
+| **OUT** | Versioning/release coordination, auto-merge, marketplace listing automation, migration of existing Coach candidates |
+
+## Repo Layout — `retro-skill`
+
+```
+retro-skill/
+├── plugin.json
+├── composer.json
+├── README.md
+├── LICENSE-MIT
+├── LICENSE-CC-BY-SA-4.0
+├── skills/retro/
+│   ├── SKILL.md
+│   └── checkpoints.yaml          (own quality gates)
+├── commands/
+│   └── retro.md                  (slash command definition)
+├── hooks/
+│   └── session-end.json          (off by default)
+├── references/
+│   ├── friction-catalog.md       (Schichten A/B/C)
+│   ├── destination-taxonomy.md   (6 categories)
+│   ├── classification-heuristic.md (friction → destination)
+│   ├── skill-discovery.md        (where + how to find skills)
+│   ├── patch-workflow.md         (source-repo, not cache)
+│   ├── eval-integration.md       (how evals inform retro)
+│   └── workflow.md               (sweep + spotlight + auto modes)
+├── scripts/
+│   ├── detect-mechanical.py      (Schicht A pre-pass)
+│   ├── find-installed-skills.sh  (mechanical discovery helper)
+│   ├── extract-coach-events.py   (optional — reads ~/.claude-coach/ if present)
+│   └── scan-cross-session.py     (fallback for Schicht C if Coach absent)
+└── docs/specs/
+    └── retro-skill.md            (mirror of this spec post-bootstrap)
+```
+
+## Commands
+
+```
+/retro                              Sweep: analyze entire current session
+/retro "<problem description>"      Spotlight: focus on specific issue
+```
+
+Plus optional auto-trigger via SessionEnd hook (off by default; user opts in).
+
+## Core Workflow
+
+```
+1. Read session transcript (current session, or last N turns)
+
+2. Mechanical pre-pass (Schicht A — Python, fast, deterministic)
+   - Tool error rates, retry clusters, output verbosity scores
+   - User correction phrases, prompt repetition, sequence patterns
+   - Tool sequence n-grams, wrong-tool patterns
+   - Skipped verification, upstream failures (post-facto)
+   - Permission re-approval, context re-discovery
+   → produces structured "candidate findings" list
+
+3. LLM enrichment + inference (Schicht B)
+   - Reads pre-pass findings + relevant transcript excerpts
+   - Adds: skill-capability gaps, wrong skill choice, hallucination,
+     convention violations, missing skill, repeated mistakes,
+     assumption-without-asking, doc drift
+   - Filters out false positives from Schicht A
+
+4. Cross-session enrichment (Schicht C — optional)
+   - If ~/.claude-coach/events.sqlite present: query for related events
+   - Else: scan ~/.claude/projects/<slug>/*.jsonl for similar friction
+   - Identifies: "same friction again", cross-project patterns, memory drift
+
+5. Classification per finding → 1 of 6 destinations
+   - Uses references/classification-heuristic.md
+
+6. For each finding, resolve target:
+   - skill-update / new-skill: invoke Skill Discovery
+   - user-memory: determine memory file path
+   - project-rule: locate project AGENTS.md or docs/feedback/
+   - checkpoint: identify target skill's checkpoints.yaml
+   - harness-artefact: identify which agent-harness artefact
+
+7. Read evals (if available for matched skill) for context
+
+8. Generate prose proposal per finding (Why + How-to-apply, ~2-3 paragraphs)
+
+9. Present grouped proposals to user
+   - Group by destination
+   - Show ≤10 actionable items (not 1011)
+
+10. Per-proposal approval: approve / reject / edit
+
+11. Materialize approved proposals via destination-specific workflow
+    - PRs go to source repos (never cache)
+    - Per-private-repo confirmation
+    - Branch + atomic commits + PR
+
+12. Report: created PRs, written files, summary
+```
+
+## Friction Detection Catalog
+
+### Schicht A — Mechanical Pre-Pass (`scripts/detect-mechanical.py`)
+
+Fast, deterministic, regex/count-based. Runs before LLM pass to reduce token cost.
+
+| Signal | Detection | Hint at |
+|---|---|---|
+| **Tool error rate** | `exit_code != 0` or `is_error: true` in tool_use_result | Wrong tool, wrong args, missing tool |
+| **Tool retry cluster** | Same tool + similar args ≥3× within N turns | Tool misunderstanding, missing docs |
+| **Tool output verbosity** | `len(tool_result) > X` without subsequent filter call | Token waste, wrong tool (`cat` vs `head`, full Read vs Range) |
+| **Tool call count vs task** | Total tool calls / user messages ratio | Inefficiency for simple task |
+| **Sequential vs parallel** | Multiple independent calls in serial blocks | Performance waste |
+| **User correction phrases** | Regex: `^(no|nein|stop|don't|wrong|NEIN|nicht so)`, ALL CAPS, `!!!` | Classic friction |
+| **Prompt repetition** | Semantic similarity of user messages within N turns | Assistant didn't understand |
+| **Prompt sequence repetition** | n-gram match (n=2..5) over user message sequence | Workflow ripe for snippet/command |
+| **Tool sequence repetition** | n-gram match over tool_use names + arg templates | Composition opportunity, skill instruction gap |
+| **Skill in reminder vs invoke** | `<command-name>` in reminder, no matching Skill call | Skill not triggered |
+| **Wrong tool choice** | `grep` on JSON, `sed` on YAML, `cat` for huge file | Tool-not-used / wrong tool |
+| **Re-read same file** | Read tool same path ≥2× without intervening Edit | Caching opportunity |
+| **Skipped verification** | Claim "tests pass" / "fixed" without prior test/build run | Verification skip |
+| **Worked on main/master** | Git commands without prior `checkout -b` | Workflow violation |
+| **Bot attribution in commit** | Commit message contains "Generated with Claude" / "Co-Authored-By: Claude" | Known user rule violated |
+| **Outdated tool warning** | "deprecated", "is now", "use X instead" patterns in stderr | Out-of-date knowledge |
+| **Upstream failure** | `git push` fails on pre-receive, `gh pr checks` fails post-push, post-commit lint fail | Pre-push verification gap (shift-left) |
+| **Permission re-approval** | Same permission prompt approved ≥3× in session | Allowlist needed |
+
+### Schicht B — LLM Inference
+
+Requires conversational context understanding. Cannot be done mechanically.
+
+| Signal | Hint at |
+|---|---|
+| **Output quality mismatch** | Assistant's verbosity / style differed from user's implicit expectation |
+| **Wrong skill choice** | Skill X was triggered, Skill Y would have fit better |
+| **Skill capability gap** | Skill triggered, lacked guidance for sub-task |
+| **Skill description mismatch** | User question should have triggered Skill X, but its `description` doesn't match |
+| **Hallucination / fact check** | Assistant claimed X, later refuted by verification or user |
+| **Convention violation** | Code doesn't match project style — no lint fail, but off |
+| **Missing skill** | Recurring task with no installed skill matching |
+| **Wrong-destination materialization** | Assistant wrote learning to wrong file (e.g. AGENTS.md instead of feedback memory) |
+| **Repeated mistake in session** | Same error N× in same session — lesson not learned |
+| **Approval bypassed** | Assistant performed irreversible action without user confirmation |
+| **Plan / spec skipped** | Non-trivial task started without TodoWrite/plan/spec |
+| **Assumption without asking** | Assistant made an assumption later refuted; should have used spec-driven-development |
+| **Context re-discovery** | Assistant re-explored repo structure already documented in AGENTS.md |
+| **Doc drift** | Assistant used outdated API/library version when context7 would have helped |
+
+### Schicht C — Cross-Session (Persistence Required)
+
+Not detectable from a single session. Optional Coach-events read; otherwise session-file scan.
+
+| Signal | Hint at | Source |
+|---|---|---|
+| **Same friction again** | Same correction across multiple sessions — memory didn't stick | Coach events OR session JSONL scan |
+| **Cross-project pattern** | Same friction class in N≥2 projects | Multi-session JSONL scan grouped by project |
+| **Memory drift** | feedback_*.md exists but assistant violated it anyway → skill needs it more prominently | Session JSONL diff against memory files |
+| **Skill update ineffective** | Previous PR to skill X, same bug returned afterward | Git log of skill repo + session JSONL |
+
+**Persistence strategy:** if `~/.claude-coach/events.sqlite` exists, query it (fast, indexed). Else scan `~/.claude/projects/<slug>/*.jsonl` (always present, slower). No new state introduced by retro-skill.
+
+## Destination Taxonomy
+
+Six categories, statically documented in `references/destination-taxonomy.md`.
+
+| Destination | When | Materialization Format |
+|---|---|---|
+| `user-memory` | Personal preference, style, recurring quirk across projects | `~/.claude/projects/<slug>/memory/feedback_<slug>.md` (existing schema: frontmatter `name/description/type/originSessionId` + body Why/How-to-apply) |
+| `project-rule` | Project-specific convention or command | `<project>/docs/feedback/<slug>.md` + AGENTS.md index entry |
+| `skill-update` | Existing skill missing instruction or has wrong guidance | PR to skill **source repo** (not cache) via `skill-repo` convention |
+| `new-skill` | Friction is skill-shaped gap, no existing skill matches | Invoke `skill-repo` scaffolding for new repo |
+| `checkpoint` | Mechanically detectable rule, regex/script possible | YAML entry in target skill's `checkpoints.yaml` (via `automated-assessment` schema) |
+| `harness-artefact` | Repo missing hook / CI / template | Invoke `agent-harness` bootstrap for specific artefact (pre-commit hook, PR template, CI workflow) |
+
+## Classification Heuristic (Friction → Destination)
+
+Excerpt; full table in `references/classification-heuristic.md`.
+
+```
+Tool output verbosity        → skill-update on tool-owner skill
+                                (e.g. file-search, data-tools)
+
+User correction (style)      → user-memory (feedback_<slug>.md)
+
+User correction (convention) → project-rule (docs/feedback/<slug>.md)
+
+Skill not triggered          → skill-update (description) OR
+                                agent-harness (delegation map)
+                                — LLM decides from context
+
+Wrong tool choice            → skill-update on tool-owner
+                                OR cli-tools-skill (selection heuristic)
+
+Known rule violated          → skill-update — skill is ignoring user-memory
+
+Skipped verification         → harness-artefact (PR-template question)
+                                OR project-rule (CLAUDE.md rule)
+
+Upstream failure             → harness-artefact (pre-commit hook)
+                                OR skill-update (verification step)
+                                OR checkpoint (mechanical check)
+                                OR project-rule
+
+Outdated tool                → skill-update on tool-owner (version bump)
+                                OR user-memory (user uses outdated setup)
+
+Missing skill                → new-skill via skill-repo
+
+Cross-project pattern        → skill-update (promotion from feedback files)
+
+Permission re-approval       → user-memory + invoke update-config skill
+
+Context re-discovery         → project-rule — improve AGENTS.md
+                                OR skill-update on agent-rules-skill
+
+Assumption without asking    → skill-update on spec-driven-development
+                                (trigger description) OR user-memory
+
+Doc drift                    → skill-update on context7-skill trigger
+                                OR project-rule
+```
+
+## Skill Discovery (Runtime)
+
+Documented in `references/skill-discovery.md`.
+
+**Search paths (in order):**
+
+1. `<project>/.claude/skills/` — project-local
+2. `~/.claude/skills/` — user-installed
+3. `~/.claude/plugins/cache/*/skills/` — marketplace + private plugins
+4. Plugin manifests (`~/.claude/plugins/installed.json` or equivalent) for repo URLs
+
+**Match heuristic:**
+
+1. Read each `SKILL.md` frontmatter `description`
+2. LLM matches friction-topic against descriptions (uses pre-extracted keyword index for speed)
+3. If 1 match → propose
+4. If multiple matches → ask user
+5. If no match → propose `new-skill`
+
+**Repo-URL extraction (for patch target):**
+
+1. `plugin.json` `metadata.repository`
+2. `composer.json` `support.source` or `homepage`
+3. Git remote in skill directory (if it's a git repo)
+4. Last resort: ask user
+
+**Evals integration (if present):**
+
+When matched skill has `evals/` directory:
+- Read eval files for context during classification ("does this friction contradict an eval?")
+- For skill-update proposals: check if eval covers the area; if not, propose eval stub alongside fix (TDD-style)
+- For CI eval failures (via `gh api repos/<org>/<repo>/actions/runs`): pre-emptive findings even without user friction
+
+**Private skill handling:**
+
+Auto-discover via search paths. Before any PR creation:
+> "Target repo `git.netresearch.de/x/y` (private). Proceed? [yes/no]"
+
+Mitigates accidental leak of patches into wrong/public repos.
+
+## Patch Workflow (Source Repo, Never Cache)
+
+Documented in `references/patch-workflow.md`.
+
+**Core rule:** patches always target the source repo. Cache (`~/.claude/plugins/cache/`) is overwritten on plugin update; edits there are lost.
+
+**Workflow:**
+
+```
+1. Discovery returns skill location + source repo URL
+
+2. Workspace selection (in this order):
+   a. ~/p/<skill-name>/main/ exists as worktree AND is clean → use it
+      (matches user's setup, enables manual follow-up)
+   b. Else: clone fresh into /tmp/retro-workspace/<skill>/
+   
+3. Branch: feat/retro-<short-slug>
+   - Slug derived from finding title
+
+4. Edit + atomic commit per logical change
+   - No --no-verify (preserve hooks)
+   - No --no-gpg-sign (preserve user's SSH signing — see user memory)
+   - No bot attribution in commit message (see user memory)
+   - Conventional Commits format
+
+5. Push branch + create PR via gh / glab
+   - PR body references the friction it resolves
+   - PR title follows Conventional Commits
+   - For private hosts: use $GITLAB_HOST or --hostname git.netresearch.de
+
+6. Cache stays unchanged. Plugin update mechanism is responsible
+   for pulling the new skill version after merge.
+   /retro does not trigger plugin updates.
+```
+
+**Edge cases:**
+
+| Case | Behavior |
+|---|---|
+| Skill in `~/.claude/skills/<name>/` no git remote | User-local, no source. Ask user: "edit locally, or scaffold a new repo?" |
+| Skill in `<project>/.claude/skills/` | Patch goes to project repo (not skill repo) |
+| Cache diverged from source (manual hack) | Show diff, ask user before proceeding |
+| Private repo unauthenticated | Graceful failure, user instruction |
+| Source repo URL unresolvable | Ask user; offer to scaffold new repo |
+| User on detached HEAD or dirty worktree | Skip worktree, use /tmp clone |
+
+## Companion Repo Changes
+
+### `agent-harness-skill`
+
+- **EDIT** `skills/agent-harness/SKILL.md`:
+  - Add Key Principle: *"Does not own learning. Delegates session learning to retro-skill. Verifies that integration points exist."*
+  - Add Delegation entry: *Session retrospectives and learning materialization → `@retro`*
+- **EDIT** `references/skill-integration-map.md`: new section "retro-skill" describing what Harness expects (PR-template retro question, optional SessionEnd hook configured)
+- **EDIT** `references/harness-engineering-overview.md`: add line *"Harness does not store learning itself. It provides rails (memory files, rule files, CI checks, hooks, review templates). Learning is performed by retro-skill."*
+- **EDIT** `templates/pull_request_template.md.tmpl` and `templates/merge_request_template.md.tmpl`:
+  ```markdown
+  ## Retro
+  - [ ] Was a reusable pattern detected? If yes, was it routed via /retro?
+  ```
+- **NEW Checkpoint AH-22** (warning, Level 3):
+  ```yaml
+  - id: AH-22
+    type: regex
+    target: "{.github/pull_request_template.md,.github/PULL_REQUEST_TEMPLATE/*,.gitlab/merge_request_templates/*}"
+    value: "(?i)retro|reusable.*pattern"
+    severity: warning
+    desc: "PR/MR template includes retro question for agent-authored work"
+  ```
+- **NEW Checkpoint AH-23** (info, Level 3):
+  ```yaml
+  - id: AH-23
+    type: file_exists
+    target: ".claude/hooks/session-end.json"
+    severity: info
+    desc: "SessionEnd hook configured if auto-retro is desired (optional)"
+  ```
+
+### `agent-rules-skill`
+
+- **NEW** `references/feedback-memory-schema.md`: documents the existing `feedback_<slug>.md` format as canonical project-rule materialization. Frontmatter (`name`, `description`, `type: feedback`, `originSessionId`) + body (`**Why:**`, `**How to apply:**`).
+- **EDIT** `assets/root-thin.md`: optional reference to `docs/feedback/` directory if it exists.
+- **EDIT** `references/output-structure.md`: clarify *AGENTS.md = index, feedback memory = `docs/feedback/<slug>.md`*.
+
+### `skill-repo-skill`
+
+- **NEW** `assets/.github/ISSUE_TEMPLATE/skill-learning.yml`:
+  ```yaml
+  name: Skill learning
+  description: Capture a reusable learning from an agent session
+  body:
+    - type: textarea
+      id: observed
+      attributes: {label: Observed friction}
+    - type: textarea
+      id: expected
+      attributes: {label: Desired future behavior}
+    - type: textarea
+      id: proposed-change
+      attributes: {label: Proposed skill change}
+    - type: dropdown
+      id: target
+      attributes:
+        label: Target area
+        options: [SKILL.md, references/, scripts/, templates/, checkpoints.yaml, evals/]
+  ```
+- **EDIT** PR template — add "Learning Source" block: *"Came from /retro? Reusable beyond one project? Stays focused, no project-specific rules?"*
+- **NEW** `references/materialization-contract.md`: contract between retro-skill and skill repos (branch convention `feat/retro-<slug>`, commit format Conventional Commits, PR-body schema, requirement to read `evals/` if present).
+
+### `automated-assessment-skill`
+
+- **NEW** `references/learning-derived-checkpoints.md`: YAML schema spec + examples for friction-derived checkpoints. When retro-skill proposes destination=`checkpoint`, this reference is the contract for the YAML it should produce.
+
+### `claude-coach-plugin`
+
+**No changes.** Coach stays installed and unchanged. retro-skill optionally reads `~/.claude-coach/events.sqlite` for Schicht C; absence is graceful (falls back to JSONL scan).
+
+## Boundaries
+
+**Always do:**
+- LLM is the primary classifier (no Coach-hook-pipeline dependency)
+- 1 approval per materialization (not per candidate)
+- Per-private-repo confirmation before PR
+- Materialization format follows owner-skill convention
+- Patches go to source repo, never cache
+- Preserve commit signing (no `--no-gpg-sign`)
+- Conventional Commits in commit messages and PR titles
+
+**Ask first:**
+- Skill-match ambiguity (>1 possible skill)
+- Auto-mode activation (SessionEnd hook)
+- Private repo targets
+- Cache diverged from source
+- User-local skills with no git remote
+
+**Never:**
+- Auto-merge of PRs
+- Write to user/project memory without approval
+- Generate 1000+ candidates (Coach anti-pattern)
+- Continuous background hooks (Coach anti-pattern; only optional SessionEnd)
+- Hardcode static skill list
+- Add bot attribution to commits or PRs
+- Skip hooks (`--no-verify`)
+- Patch the cache directory
+
+## Success Criteria
+
+1. **Sweep mode** delivers ≤10 actionable proposals per medium session (not 1011)
+2. **One LLM pass** for analysis + classification (no multi-round polling)
+3. **≤5 tool calls** for skill discovery (cached per session)
+4. **Token budget:** `/retro` of a 2-hour session stays under target X (X tbd post-prototype, dramatically below continuous Coach pipeline)
+5. **Discovery** finds local + marketplace + private skills
+6. **Materialization** follows owner-skill convention (smoke test per destination)
+7. **Spotlight mode** works without full session context ("describe the problem")
+8. **Coach independence:** `/retro` runs cleanly without Coach installed
+9. **Coach integration:** when present, Coach events accelerate Schicht C
+10. **Patches land in source repo**, never cache
+11. **Evals consulted** when target skill has them
+12. **AH-22 + AH-23** checkpoints green in test repo
+13. **All 14 Schicht-A signals** detected by `detect-mechanical.py`
+14. **All 14 Schicht-B signals** in `friction-catalog.md` with prose example each
+15. **All 4 Schicht-C signals** documented with persistence strategy
+
+## Verification Plan
+
+| Step | Who | How |
+|---|---|---|
+| Discovery finds skills in 4 paths | mechanical | `find-installed-skills.sh` against synthetic test layout |
+| Mechanical pre-pass detects all Schicht-A signals | mechanical | unit test: synthetic transcript with each signal, assert detection |
+| Classification covers 6 destinations | manual | test sessions with known friction patterns |
+| Token budget held | mechanical | telemetry per `/retro` run, fail CI if regression |
+| Materialization smoke per destination | manual | one friction per destination → one materialization |
+| Private-repo confirmation triggers | mechanical | mock run with `git.netresearch.de` URL |
+| Coach optional | mechanical | `/retro` without `~/.claude-coach/` runs clean |
+| Coach integration | mechanical | `/retro` with `~/.claude-coach/` reads events |
+| Patch goes to source not cache | mechanical | assert PR target is repo URL, never `~/.claude/plugins/cache/` |
+| Worktree preference | mechanical | when `~/p/<name>/main/` clean → workspace selected; when dirty → /tmp fallback |
+| Evals read when present | mechanical | mock skill with `evals/` → assert evals in LLM context payload |
+| Commit signing preserved | mechanical | post-commit `git log --show-signature` shows G |
+| No bot attribution | mechanical | grep commit messages for known anti-patterns |
+
+## Open Questions
+
+All resolved during Phase-1 elicitation.
+
+| ID | Question | Resolution |
+|---|---|---|
+| Q1 (orig) | Coach candidates schema migration | N/A — Coach unchanged |
+| Q2 (orig) | Classifier: Python vs LLM | Python for Schicht A (mechanical), LLM for Schicht B (inference) |
+| Q3 (orig) | Cross-repo promotion trigger | Manual ("fix it for all skills"), no algorithm |
+| Q4 | Coach fate | Keep as optional data source, not modified |
+| Q5 | New skill home | New repo `netresearch/retro-skill` |
+| Q6 | Commands | `/retro` (sweep + spotlight via argument) + optional SessionEnd hook |
+| Q7 | Routing contract necessity | Static taxonomy (6 destinations) + dynamic skill discovery — best of both |
+| Q8 | Skill name | `retro` (not `compound-engineering`, not `skill-ratchet` — too narrow/buzzy) |
+| Q9 | Spotlight granularity | Single command with optional argument; no separate `/fix-skill` |
+| Q10 | Discovery scope | Auto-discovery including private; per-PR confirmation gates leak risk |
+| Q11 | Friction catalog scope | All A + all B + all C in v0.1 (no MVP cut) |
+| Q12 | Patch location | Source repo, never cache |
+| Q13 | Evals integration | Yes, both for context and as TDD-stub for new updates |
+
+## Out of Scope
+
+- Coach internal changes (separate task; Coach has independent backlog)
+- Migration of existing 1011 Coach candidates (separate cleanup task)
+- Versioning / release coordination of the 4 companion skills (separate per-skill release flow)
+- Auto-merge or CI integration for PRs created by `/retro`
+- Multi-session aggregation beyond Schicht C detection (each `/retro` is self-contained)
+- Marketplace listing automation for `new-skill` destination
+- Cross-organization skill promotion (e.g. open-sourcing private learnings)
+- Telemetry storage / dashboards (focus on per-session efficacy)
+
+## References
+
+- Subagent field report (session 2026-05-11): manual workflow analysis showing Coach unused, `feedback_*.md` schema canonical
+- `~/.claude-coach/candidates.json`: 1011 pending / 0 approved evidence
+- `~/.claude/projects/-home-sme-p/memory/feedback_*.md`: 8 existing files demonstrating canonical format
+- Addy Osmani, "Agent Harness Engineering": ratchet concept, but materialization belongs in retro-skill not in agent-harness
+- `~/p/agent-harness-skill/main/skills/agent-harness/checkpoints.yaml`: existing AH-* numbering scheme (Level 3 = 20s; AH-22, AH-23 free)
+- `~/p/claude-coach-plugin/skills/coach/SKILL.md`: existing Coach signal taxonomy (informs Schicht A patterns)
+
+## What's Next (post-approval)
+
+- **Phase 2 (PLAN):** Implementation order — `retro-skill` bootstrap first, then 4 companion PRs in parallel; risks; verification gates
+- **Phase 3 (TASKS):** Per-repo file-level tasks with acceptance + verify
+- **Phase 4 (IMPLEMENT):** Parallel execution via subagents

--- a/docs/specs/retro-skill.md
+++ b/docs/specs/retro-skill.md
@@ -2,12 +2,12 @@
 
 | | |
 |---|---|
-| **Status** | Draft (Phase 1 — for review) |
+| **Status** | Phase 1 implemented (v0.1.1); spec is the canonical contract |
 | **Owner Repo** | `agent-harness-skill` (this spec) |
-| **Implementation Repo** | `netresearch/retro-skill` (new, to be created) |
+| **Implementation Repo** | [netresearch/retro-skill](https://github.com/netresearch/retro-skill) — exists at v0.1.0+; v0.1.1 adds Schicht D + audit mode |
 | **Companion Changes** | 4 existing skill repos (small edits) |
 | **Author** | Sebastian Mendel |
-| **Date** | 2026-05-11 |
+| **Date** | 2026-05-11 (v0.1 spec); 2026-05-12 (v0.1.1 amendments) |
 
 ## Objective
 
@@ -26,52 +26,60 @@ Field investigation of the user's own workflow (subagent report, session 2026-05
 
 | | |
 |---|---|
-| **NEW** | `netresearch/retro-skill` — own repo, own marketplace entry |
+| **IMPLEMENTED** | `netresearch/retro-skill` v0.1.1 — own repo, own marketplace entry, on GitHub |
 | **EDIT (small)** | 4 repos for materialization conventions: `agent-harness-skill`, `agent-rules-skill`, `skill-repo-skill`, `automated-assessment-skill` |
 | **NO CHANGE** | `claude-coach-plugin` — Coach stays as-is, optionally read by retro-skill as a data source |
-| **OUT** | Versioning/release coordination, auto-merge, marketplace listing automation, migration of existing Coach candidates |
+| **OUT** | Versioning/release coordination, auto-merge, marketplace listing automation, migration of existing Coach candidates, external-feedback integrations (Sentry/Jira/Slack — future direction) |
 
-## Repo Layout — `retro-skill`
+## Repo Layout — `retro-skill` (as-built, v0.1.1)
 
 ```
 retro-skill/
-├── plugin.json
-├── composer.json
+├── .claude-plugin/
+│   └── plugin.json               (Claude marketplace manifest)
+├── composer.json                 (skill-repo-skill convention)
 ├── README.md
 ├── LICENSE-MIT
 ├── LICENSE-CC-BY-SA-4.0
+├── AGENTS.md
 ├── skills/retro/
 │   ├── SKILL.md
 │   └── checkpoints.yaml          (own quality gates)
 ├── commands/
-│   └── retro.md                  (slash command definition)
+│   └── retro.md                  (slash command definition; 4 modes)
 ├── hooks/
-│   └── session-end.json          (off by default)
+│   └── session-end.json          (off by default; reads stdin JSON)
 ├── references/
-│   ├── friction-catalog.md       (Schichten A/B/C)
+│   ├── friction-catalog.md       (Schichten A/B/C/D/E)
 │   ├── destination-taxonomy.md   (6 categories)
 │   ├── classification-heuristic.md (friction → destination)
 │   ├── skill-discovery.md        (where + how to find skills)
 │   ├── patch-workflow.md         (source-repo, not cache)
 │   ├── eval-integration.md       (how evals inform retro)
-│   └── workflow.md               (sweep + spotlight + auto modes)
+│   └── workflow.md               (sweep + spotlight + outcome + audit + auto modes)
 ├── scripts/
-│   ├── detect-mechanical.py      (Schicht A pre-pass)
+│   ├── detect-mechanical.py      (Schicht A pre-pass; 13 of 18 signals implemented)
 │   ├── find-installed-skills.sh  (mechanical discovery helper)
 │   ├── extract-coach-events.py   (optional — reads ~/.claude-coach/ if present)
 │   └── scan-cross-session.py     (fallback for Schicht C if Coach absent)
+├── tests/
+│   └── test_detect_mechanical.py (unit tests for Schicht A)
+├── .github/workflows/
+│   └── lint.yml                  (py_compile, bash -n, jq/yaml validate, tests, DCO)
 └── docs/specs/
-    └── retro-skill.md            (mirror of this spec post-bootstrap)
+    └── retro-skill.md            (mirror of this spec)
 ```
 
-## Commands
+## Commands (v0.1.1)
 
 ```
-/retro                              Sweep: analyze entire current session
-/retro "<problem description>"      Spotlight: focus on specific issue
+/retro                                Sweep — full current session
+/retro "<problem description>"        Spotlight — focus on one issue
+/retro outcome [session-id|--since N] Outcome — post-hoc review of past session(s)
+/retro audit [--scope X]              Audit — cross-session architectural review
 ```
 
-Plus optional auto-trigger via SessionEnd hook (off by default; user opts in).
+Plus optional auto-trigger via SessionEnd hook (off by default; user opts in). All four explicit modes share the same pipeline (discovery, classification, materialization) but differ in which detection Schicht they activate.
 
 ## Core Workflow
 
@@ -184,8 +192,40 @@ Not detectable from a single session. Optional Coach-events read; otherwise sess
 | **Cross-project pattern** | Same friction class in N≥2 projects | Multi-session JSONL scan grouped by project |
 | **Memory drift** | feedback_*.md exists but assistant violated it anyway → skill needs it more prominently | Session JSONL diff against memory files |
 | **Skill update ineffective** | Previous PR to skill X, same bug returned afterward | Git log of skill repo + session JSONL |
+| **Follow-up-fix session** | Later session exists primarily to fix what earlier session broke | Cross-session JSONL + git log |
 
 **Persistence strategy:** if `~/.claude-coach/events.sqlite` exists, query it (fast, indexed). Else scan `~/.claude/projects/<slug>/*.jsonl` (always present, slower). No new state introduced by retro-skill.
+
+### Schicht D — Outcome (Post-Session; v0.1.x extension)
+
+What happened to session output **after** it left the session. Requires latency (days–weeks); best run monthly via `/retro outcome --since 30d`, not at session end.
+
+| Signal | Detection | Hint at |
+|---|---|---|
+| **Session commit reverted** | `git log --grep="revert" + ($commit_sha)` | Output was wrong |
+| **Session commit superseded** | Same file touched again within 7 days, diff substantively reverts | Output unfinished/wrong direction |
+| **Session PR closed without merge** | `gh pr view --json closedAt,merged,state` | Output rejected |
+| **Session PR required major changes** | `gh pr view --json reviews` filter CHANGES_REQUESTED | Output below standard |
+| **CI failed on session commit** | `gh run list --commit $sha --json conclusion` | Output broken |
+| **Issue filed referencing session files** | `gh issue list --search "filename after:$date"` | Output caused a bug |
+| **Follow-up session detected** | Schicht C5 cross-referenced from outcome perspective | Session output didn't last |
+
+Full list (10 signals) in `references/friction-catalog.md`. Catalogued in v0.1.1; detector implementation deferred to v0.1.x.
+
+### Schicht E — Constitutional (Audit mode only; v0.1.x extension)
+
+Cross-session architectural patterns. Output class is "architectural finding", not "friction finding". Quarterly cadence; tech-lead actor.
+
+| Signal | Detection | Hint at |
+|---|---|---|
+| **ADR violation pattern** | Active ADRs declare X; recent N sessions violated X | Design erosion |
+| **AGENTS.md rule compliance trend** | feedback files exist but sessions repeatedly violate them | Rules not reaching agent |
+| **Test coverage trend** | Coverage trending down over recent commits | Quality discipline regression |
+| **Skill-inventory drift** | Skill count growing without scope; redundant skills | Bloat / fragmentation |
+| **Dependency staleness trend** | A16 (outdated tool) recurring | Library maintenance gap |
+| **Convention divergence** | Style/naming diverging | Onboarding or review gap |
+
+Full list (6 signals) in `references/friction-catalog.md`. Catalogued in v0.1.1.
 
 ## Destination Taxonomy
 
@@ -348,23 +388,8 @@ Documented in `references/patch-workflow.md`.
   ## Retro
   - [ ] Was a reusable pattern detected? If yes, was it routed via /retro?
   ```
-- **NEW Checkpoint AH-22** (warning, Level 3):
-  ```yaml
-  - id: AH-22
-    type: regex
-    target: "{.github/pull_request_template.md,.github/PULL_REQUEST_TEMPLATE/*,.gitlab/merge_request_templates/*}"
-    value: "(?i)retro|reusable.*pattern"
-    severity: warning
-    desc: "PR/MR template includes retro question for agent-authored work"
-  ```
-- **NEW Checkpoint AH-23** (info, Level 3):
-  ```yaml
-  - id: AH-23
-    type: file_exists
-    target: ".claude/hooks/session-end.json"
-    severity: info
-    desc: "SessionEnd hook configured if auto-retro is desired (optional)"
-  ```
+- **NEW Checkpoint AH-22** (warning, Level 3): see `skills/agent-harness/checkpoints.yaml` for the authoritative YAML. Verifies PR/MR template includes a retro question via `grep -liE '(retro|reusable.*pattern)' ...`. Uses `type: command` because brace-expansion glob with regex matching across multiple optional files isn't expressible as `type: regex`.
+- **NEW Checkpoint AH-23** (info, Level 3): see `skills/agent-harness/checkpoints.yaml`. `type: file_exists` against `{.claude/hooks/session-end.json,hooks/session-end.json}`. Optional convenience; doesn't fail audits, just hints at auto-retro availability.
 
 ### `agent-rules-skill`
 
@@ -446,10 +471,11 @@ Documented in `references/patch-workflow.md`.
 9. **Coach integration:** when present, Coach events accelerate Schicht C
 10. **Patches land in source repo**, never cache
 11. **Evals consulted** when target skill has them
-12. **AH-22 + AH-23** checkpoints green in test repo
-13. **All 14 Schicht-A signals** detected by `detect-mechanical.py`
-14. **All 14 Schicht-B signals** in `friction-catalog.md` with prose example each
-15. **All 4 Schicht-C signals** documented with persistence strategy
+12. **AH-22** emits warning when retro question absent from PR/MR template; **AH-23** emits info when SessionEnd hook present. Neither becomes error.
+13. **13 of 18 Schicht-A signals** detected by `detect-mechanical.py` in v0.1.1 (A4, A5, A11, A13, A18 catalogued but deferred). All 18 documented with synthetic-transcript pattern in `references/friction-catalog.md`.
+14. **All 14 Schicht-B signals** in `friction-catalog.md` with prose example each (LLM-driven; no separate code)
+15. **All 5 Schicht-C signals** documented (C5 follow-up-fix added v0.1.1)
+16. **All 10 Schicht-D signals (Outcome) and 6 Schicht-E signals (Constitutional/audit) catalogued in v0.1.1**; detectors deferred to v0.1.x follow-up
 
 ## Verification Plan
 

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -54,16 +54,16 @@ Report the repo's maturity level (1, 2, or 3) and show what is needed to reach t
 - **AGENTS.md is an index, not an encyclopedia.** Keep it under 150 lines. Put detail in `docs/`.
 - **Enforcement is project-level.** CI workflows, git hooks, and branch protection enforce the harness -- not this skill at runtime.
 - **Verify first, bootstrap second.** Always run verification before creating artefacts. The skill checks artefacts, not tools.
-- **Delegate specialist work.** See `references/skill-integration-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`, `@retro`). The harness does **not** invoke retro-skill at runtime; it verifies that the integration points retro-skill needs (PR/MR retro question, optional SessionEnd hook) exist in target repos.
-- **Does not own learning.** Session learning, retrospection, outcome review, and constitutional audits are delegated to `retro-skill`. The harness verifies integration points exist but does not store learnings or invoke retro at runtime.
+- **Delegate specialist work.** See `references/skill-integration-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`, `@retro`).
+- **Does not own learning.** Session retrospection, outcome review, and constitutional audits are delegated to `retro-skill`. The harness verifies integration points exist (AH-22, AH-23) but does not invoke retro at runtime.
 
 ## Maturity Levels
 
-**Level 1 -- Basic:** AGENTS.md exists, serves as an index (not a wall of text), and documents available commands.
+**Level 1 -- Basic:** AGENTS.md exists, is an index, documents commands.
 
-**Level 2 -- Verified:** CI checks enforce harness integrity, all AGENTS.md references resolve, documented commands match actual Makefile/script targets, and ARCHITECTURE.md exists.
+**Level 2 -- Verified:** CI enforces harness integrity, AGENTS.md references resolve, commands match Makefile/scripts, ARCHITECTURE.md exists.
 
-**Level 3 -- Enforced:** Branch protection requires harness CI to pass, git hooks auto-activate on clone, PR template includes harness checklist, and drift detection runs on every push.
+**Level 3 -- Enforced:** Branch protection requires harness CI, git hooks auto-activate, PR template includes checklist, drift detection on push.
 
 See `references/maturity-levels.md` for the full breakdown.
 

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -54,7 +54,8 @@ Report the repo's maturity level (1, 2, or 3) and show what is needed to reach t
 - **AGENTS.md is an index, not an encyclopedia.** Keep it under 150 lines. Put detail in `docs/`.
 - **Enforcement is project-level.** CI workflows, git hooks, and branch protection enforce the harness -- not this skill at runtime.
 - **Verify first, bootstrap second.** Always run verification before creating artefacts. The skill checks artefacts, not tools.
-- **Delegate specialist work.** See `references/delegation-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`).
+- **Delegate specialist work.** See `references/delegation-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`, `@retro`).
+- **Does not own learning.** Session learning, retrospection, and rule materialization are delegated to `@retro` (retro-skill). The harness verifies that integration points exist (PR/MR template includes retro question, optional SessionEnd hook configured) but does not store learnings itself.
 
 ## Maturity Levels
 

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -72,8 +72,7 @@ See `references/maturity-levels.md` for the full breakdown.
 - `references/maturity-levels.md` -- Maturity criteria and progression
 - `references/agents-md-rules.md` -- AGENTS.md authoring rules
 - `references/artefact-inventory.md` -- Harness artefacts list
-- `references/delegation-map.md` -- Skill routing map
 - `references/harness-engineering-overview.md` -- Theory: four functions, patterns
 - `references/agent-first-architecture.md` -- Legibility, layered deps, agent-first tech
 - `references/enforcement-mechanisms.md` -- 10-mechanism table (CI, hooks, protection, drift)
-- `references/skill-integration-map.md` -- Integration contracts with companion skills
+- `references/skill-integration-map.md` -- Skill routing map + integration contracts with companion skills

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -54,8 +54,8 @@ Report the repo's maturity level (1, 2, or 3) and show what is needed to reach t
 - **AGENTS.md is an index, not an encyclopedia.** Keep it under 150 lines. Put detail in `docs/`.
 - **Enforcement is project-level.** CI workflows, git hooks, and branch protection enforce the harness -- not this skill at runtime.
 - **Verify first, bootstrap second.** Always run verification before creating artefacts. The skill checks artefacts, not tools.
-- **Delegate specialist work.** See `references/delegation-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`, `@retro`).
-- **Does not own learning.** Session learning, retrospection, and rule materialization are delegated to `@retro` (retro-skill). The harness verifies that integration points exist (PR/MR template includes retro question, optional SessionEnd hook configured) but does not store learnings itself.
+- **Delegate specialist work.** See `references/skill-integration-map.md` for skill routing (`@agent-rules`, `@github-project`, `@enterprise-readiness`, `@retro`). The harness does **not** invoke retro-skill at runtime; it verifies that the integration points retro-skill needs (PR/MR retro question, optional SessionEnd hook) exist in target repos.
+- **Does not own learning.** Session learning, retrospection, outcome review, and constitutional audits are delegated to `retro-skill`. The harness verifies integration points exist but does not store learnings or invoke retro at runtime.
 
 ## Maturity Levels
 

--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -72,6 +72,25 @@ mechanical:
     severity: warning
     desc: "Git hooks auto-activate on clone (.envrc, .husky, or composer/npm install hook)"
 
+  # === RETRO-SKILL INTEGRATION ===
+  # The harness does not own learning, but verifies that integration points
+  # exist for retro-skill to route session learnings into the correct
+  # destination. See references/skill-integration-map.md (retro-skill section).
+
+  - id: AH-22
+    type: command
+    pattern: "grep -liE '(retro|reusable.*pattern)' .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE/*.md .gitlab/merge_request_templates/*.md 2>/dev/null | head -1 | grep -q ."
+    severity: warning
+    desc: "PR/MR template includes retro question for agent-authored work"
+    fix_skill: "retro"
+
+  - id: AH-23
+    type: file_exists
+    target: "{.claude/hooks/session-end.json,hooks/session-end.json}"
+    severity: info
+    desc: "SessionEnd hook configured (optional; enable for auto-trigger of /retro)"
+    fix_skill: "retro"
+
   # === QUALITY DELEGATION ENFORCEMENT ===
   # The harness delegates quality to specialist skills but MUST verify
   # the delegation produces results. These checks verify that quality

--- a/skills/agent-harness/references/harness-engineering-overview.md
+++ b/skills/agent-harness/references/harness-engineering-overview.md
@@ -44,6 +44,8 @@ Correction depends on clear, actionable error messages. A CI check that reports 
 
 Correction lives in CI annotations, hook output, and structured error reporting from verification scripts.
 
+**The harness does not store learning itself.** It provides the rails: memory files, rule files, CI checks, hooks, review templates. Learning — capturing reusable patterns from sessions and routing them to the correct destination — is performed by `retro-skill` (see `skill-integration-map.md` #12) and materialized through specialist skills (`agent-rules`, `skill-repo`, `automated-assessment`). The harness verifies the integration points exist (`AH-22`, `AH-23`) but does not own the learning loop.
+
 ## Complementary Perspectives
 
 ### Anthropic / Claude Code

--- a/skills/agent-harness/references/maturity-levels.md
+++ b/skills/agent-harness/references/maturity-levels.md
@@ -167,6 +167,8 @@ All of Level 2, plus:
 | ---------- | ----- | -------- |
 | AH-20 | PR/MR template includes harness checklist | Warning |
 | AH-21 | Git hooks auto-activate on clone (via .envrc, composer, or npm) | Warning |
+| AH-22 | PR/MR template includes retro question for agent-authored work | Warning |
+| AH-23 | SessionEnd hook configured (optional convenience for retro auto-trigger) | Info |
 | AH-34 | Mutation testing configuration exists | Info |
 | AH-35 | Code coverage configuration exists | Info |
 | -- | Assessment checkpoints pass for all applicable skills | Warning |
@@ -323,6 +325,8 @@ automated-assessment:audit --skill=agent-harness --org=netresearch
 | AH-12 | 2 | CI harness verification workflow exists (GitHub Actions or GitLab CI) | Warning | command |
 | AH-20 | 3 | PR/MR template with harness checklist | Warning | command |
 | AH-21 | 3 | Git hooks auto-activate | Warning | command |
+| AH-22 | 3 | PR/MR template includes retro question | Warning | command |
+| AH-23 | 3 | SessionEnd hook configured (optional) | Info | file_exists |
 | AH-30 | 2 | Test runner infrastructure exists | Warning | command |
 | AH-31 | 2 | PHPStan level 8+ configured (PHP only) | Warning | command |
 | AH-32 | 2 | Git hooks for pre-commit quality checks | Warning | command |

--- a/skills/agent-harness/references/skill-integration-map.md
+++ b/skills/agent-harness/references/skill-integration-map.md
@@ -228,7 +228,7 @@ The assessment generates a structured gap report from checkpoints. This report b
 
 ### 11. skill-repo-skill
 
-**What it provides:** Defines the structure of a *skill* repository: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, split licensing (MIT + CC-BY-SA-4.0), release workflows, composer integration.
+**What it provides:** Defines the structure of a *skill* repository: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, split licensing (MIT + CC-BY-SA-4.0), release workflows, composer integration. Also defines the `materialization-contract.md` followed by tools that submit PRs to skill repos (notably retro-skill).
 
 **When harness applies alongside it:** Skill repos benefit from both layers: `skill-repo-skill` verifies skill-specific structure (`.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `composer.json` conventions) via its own `validate-skill.sh`; harness layers generic agent-readiness on top (`AGENTS.md` as index, `docs/` structure, `.github/workflows/harness-verify.yml`). The two verifiers don't overlap — they target different artefacts.
 
@@ -240,6 +240,29 @@ The assessment generates a structured gap report from checkpoints. This report b
 **What harness verifies in skill repos:**
 
 - The same generic harness checkpoints apply as for any other repo (`AH-01` `AGENTS.md` exists, `AH-02` line count, `AH-12` `harness-verify.yml` exists). Skill-specific structural validation is left to `skill-repo-skill`'s own `validate-skill.sh`.
+
+---
+
+### 12. retro-skill
+
+**What it provides:** LLM-driven session retrospection. Detects friction in agent sessions (~32 signals across 3 layers: mechanical pre-pass, LLM inference, cross-session) and materializes approved learnings into one of six destinations: `user-memory`, `project-rule`, `skill-update`, `new-skill`, `checkpoint`, `harness-artefact`.
+
+**When harness delegates to it:** At end of any non-trivial session, or on-demand for specific issues. The harness does **not** invoke retro-skill at runtime; it verifies that the artefacts retro-skill needs to materialize learnings exist in the repo.
+
+**What harness expects back from a retro-active repo:**
+
+- PR/MR template contains a retro question (so contributors can flag reusable patterns to route).
+- Optional `SessionEnd` hook (`.claude/hooks/session-end.json`) is present if the team wants auto-trigger of `/retro`.
+- `docs/feedback/` directory exists when project-rule learnings have been approved.
+- Approved learnings in `docs/feedback/` follow the `feedback-memory-schema` defined by `agent-rules-skill`.
+
+**What harness verifies:**
+
+- `AH-22` (warning, Level 3): PR/MR template includes a retro question.
+- `AH-23` (info, Level 3): SessionEnd hook present (optional convenience).
+- Indirect: `AH-10` ensures any `docs/feedback/<slug>.md` referenced from AGENTS.md actually exists.
+
+**Why this delegation matters:** The harness used to risk becoming the meta-owner for "anything agent-readiness-shaped", including learning. retro-skill carves out the learning ownership cleanly, leaving the harness as a thin verifier of integration points. See `references/harness-engineering-overview.md` for the principle.
 
 ## Integration Flow Diagram
 

--- a/skills/agent-harness/templates/merge_request_template.md.tmpl
+++ b/skills/agent-harness/templates/merge_request_template.md.tmpl
@@ -9,6 +9,13 @@
 - [ ] New subsystems/directories documented
 - [ ] Exec plan created in `docs/exec-plans/active/` (if multi-file change)
 
+## Retro
+
+<!-- Did this change reveal a reusable pattern, missing rule, or skill instruction gap? -->
+<!-- If yes, route via `/retro` to the correct destination (user-memory, project-rule, skill PR, checkpoint, harness-artefact). -->
+
+- [ ] Reusable pattern detected? (N/A if purely local fix)
+
 ## Test Plan
 
 <!-- How to verify these changes work -->

--- a/skills/agent-harness/templates/pull_request_template.md.tmpl
+++ b/skills/agent-harness/templates/pull_request_template.md.tmpl
@@ -9,6 +9,13 @@
 - [ ] New subsystems/directories documented
 - [ ] Exec plan created in `docs/exec-plans/active/` (if multi-file change)
 
+## Retro
+
+<!-- Did this change reveal a reusable pattern, missing rule, or skill instruction gap? -->
+<!-- If yes, route via `/retro` to the correct destination (user-memory, project-rule, skill PR, checkpoint, harness-artefact). -->
+
+- [ ] Reusable pattern detected? (N/A if purely local fix)
+
 ## Test Plan
 
 <!-- How to verify these changes work -->


### PR DESCRIPTION
## Summary

Three commits adding the retro-skill initiative to agent-harness-skill:

1. **Spec** (Phase 1): `docs/specs/retro-skill.md` — full LLM-driven session retrospection skill specification with 3-layer friction detection, 6-destination taxonomy, runtime skill discovery, source-repo patch workflow, and verification plan
2. **Plan** (Phase 2): `docs/plans/2026-05-11-retro-skill.md` — implementation order, risks, verification gates, prerequisites
3. **Integration**: SKILL.md, checkpoints.yaml, templates, references — the harness side of retro-skill integration

## Companion PRs

- New repo: https://github.com/netresearch/retro-skill (v0.1.0 on main, includes the skill itself)
- netresearch/agent-rules-skill#48 — feedback-memory-schema reference
- netresearch/skill-repo-skill#97 — materialization-contract + PR/issue templates
- netresearch/automated-assessment-skill#41 — learning-derived-checkpoints reference

## Changes in this PR

### Checkpoints
- **AH-22** (warning, Level 3): PR/MR template includes retro question (`fix_skill: retro`)
- **AH-23** (info, Level 3): SessionEnd hook configured for auto-trigger (`fix_skill: retro`)

### SKILL.md
- New Key Principle: 'Does not own learning' — harness verifies integration points, retro-skill owns the learning loop
- Adds `@retro` to delegation list

### references/
- `skill-integration-map.md` adds section #12 (retro-skill): what it provides, what harness expects back, what harness verifies, why this delegation matters
- `harness-engineering-overview.md` adds explicit statement that harness does not store learning itself

### Templates
- Both `pull_request_template.md.tmpl` and `merge_request_template.md.tmpl` gain a `## Retro` section asking 'Reusable pattern detected?'

## Anlass (Why now)

Field investigation: `~/.claude-coach/candidates.json` shows 1011 pending / 0 approved / 0 rejected — the Coach approval pipeline is write-only. The user materializes learnings manually via `feedback_<slug>.md` files (8 existing canonical examples) and direct skill PRs, but no reusable skill captures that workflow.

retro-skill formalizes that workflow as an LLM-driven session pass. The harness recognizes retro-skill as the learning owner and stops itself from drifting into the meta-monolith trap.

## Test plan

- [x] AH-22/AH-23 IDs free in existing 20-29 Level-3 range (verified)
- [x] All 4 companion PRs reference this spec
- [ ] retro-skill discovery script finds AH-22 in real repos
- [ ] PR template renders correctly after harness bootstrap
- [ ] Verify-harness.sh smoke test passes against retro-skill repo itself