### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-harness",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Use when making a repo agent-ready, verifying harness consistency, checking for documentation drift, bootstrapping harness infrastructure (AGENTS.md as index, docs/ structure, CI verification, enforcement mechanisms), or auditing repo agent-readiness maturity level.",
   "repository": "https://github.com/netresearch/agent-harness-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires Bash, Read, Write, Edit, Glob, Grep tools"
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.2.0"
+  version: "1.3.0"
   repository: https://github.com/netresearch/agent-harness-skill
 allowed-tools: Bash(git:*,make:*,bash:*,wc:*,test:*,chmod:*) Read Write Edit Glob Grep Agent
 ---


### PR DESCRIPTION
## Release v1.3.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/agent-harness/SKILL.md` frontmatter `metadata.version` from `1.2.0` to `1.3.0`.

### Highlights since v1.2.0

- **Retro-skill integration** as learning delegation target — Phase-1 spec for LLM-driven session retrospection and Phase-2 implementation plan (#24).
- **Checkpoint hardening**: rewritten to satisfy assessment runner allowlist; AH-02 detects missing AGENTS.md, AH-21 covers legacy + Husky v9 hook paths, AH-31 simplifies PHPStan-level detection (#20, #22).
- **Operational guidance**: OpenAI harness operational patterns, agent-first architecture reference, layer-stack ordering corrections, enforcement-mechanisms and skill-integration-map citations (#18, #23).
- **CI/release hygiene**: CI badges in README, release workflow triggers/permissions corrected per SR-31 policy, SKILL.md trimmed under the 500-word cap (#19, #21).
- **Maintenance**: `step-security/harden-runner` digest refreshes (#17, #25).

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
