### PR TITLE
feat(checkpoints): raise AH-36 severity from info to warning

### DIFF
--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -147,5 +147,5 @@ mechanical:
       H="$H .lefthook.yml .pre-commit-config.yaml";
       ! grep -rlE "$K" .github/workflows .gitlab-ci.yml 2>/dev/null | head -1 | grep -q .
       || grep -rlE "$K" $H 2>/dev/null | head -1 | grep -q .
-    severity: info
+    severity: warning
     desc: "If CI runs a fast-check command, a hook config should reference at least one fast-check command too (best-effort CI/hook parity)"

--- a/skills/agent-harness/references/maturity-levels.md
+++ b/skills/agent-harness/references/maturity-levels.md
@@ -92,7 +92,7 @@ All of Level 1, plus:
 | AH-31 | PHPStan configured at level 8+ (PHP projects only) | Warning |
 | AH-32 | Git hooks configured for pre-commit quality checks — must mirror CI's fast checks (see CI/Hook Parity Principle in `references/enforcement-mechanisms.md`; skill/Python projects: prefer `.pre-commit-config.yaml`) | Warning |
 | AH-33 | At least one test file exists (multi-language) | Error |
-| AH-36 | Hook config references at least one of CI's fast-check commands (best-effort parity check) | Info |
+| AH-36 | Hook config references at least one of CI's fast-check commands (best-effort parity check) | Warning |
 
 > **Note:** AH-30..AH-33 are assessed via the automated-assessment checkpoint runner (`/assess agent-harness`), not by `verify-harness.sh`. The verification script covers structural harness checks; quality delegation checkpoints are evaluated by the assessment skill.
 
@@ -334,4 +334,4 @@ automated-assessment:audit --skill=agent-harness --org=netresearch
 | AH-33 | 2 | At least one test file exists (multi-language) | Error | command |
 | AH-34 | 3 | Mutation testing configuration exists | Info | file_exists |
 | AH-35 | 3 | Code coverage configuration exists | Info | file_exists |
-| AH-36 | 2 | Hook config references at least one of CI's fast-check commands (parity) | Info | command |
+| AH-36 | 2 | Hook config references at least one of CI's fast-check commands (parity) | Warning | command |

--- a/skills/agent-harness/references/maturity-levels.md
+++ b/skills/agent-harness/references/maturity-levels.md
@@ -94,7 +94,7 @@ All of Level 1, plus:
 | AH-33 | At least one test file exists (multi-language) | Error |
 | AH-36 | Hook config references at least one of CI's fast-check commands (best-effort parity check) | Warning |
 
-> **Note:** AH-30..AH-33 are assessed via the automated-assessment checkpoint runner (`/assess agent-harness`), not by `verify-harness.sh`. The verification script covers structural harness checks; quality delegation checkpoints are evaluated by the assessment skill.
+> **Note:** AH-30..AH-33 and AH-36 are assessed via the automated-assessment checkpoint runner (`/assess agent-harness`), not by `verify-harness.sh`. The verification script covers structural harness checks; quality delegation checkpoints are evaluated by the assessment skill.
 
 ### What it gives you
 


### PR DESCRIPTION
## Summary

Raises AH-36 (CI/Hook keyword-parity check) from `info` to `warning` now that the fleet rollout has provided empirical evidence the keyword heuristic doesn't fire false positives.

Implements the deferred bump tracked since [#27](https://github.com/netresearch/agent-harness-skill/pull/27) introduced AH-36.

## Evidence

Ran the AH-36 check pattern against all 41 NR skill repo worktrees on 2026-05-23 after the fleet `.pre-commit-config.yaml` rollout settled:

- **39/41 PASS** (37 by having both CI fast-checks AND matching hook references; 2 trivially because their CI runs no fast-check command, so there is no parity to enforce)
- **2/41 FAIL** — both are local stale-clone artifacts:
  - `agents-skill` is a GitHub-redirect alias for `agent-rules-skill` (same upstream repo, two local clones); the upstream correctly has the config
  - `extension-assessment-skill` is a second worktree of `automated-assessment-skill`; the upstream correctly has the config
- **0 true false positives across 38 unique NR skill repos.**

The keyword heuristic (`composer ci:`, `golangci-lint`, `go vet`, `gofmt`, `validate-skill`, `validate.yml`, `markdownlint`, `yamllint`, `biome`, `eslint`, `tsc`, `ruff`, `black`, `mypy`, `pyright`, `prettier`, `stylelint`, `cargo clippy`/`fmt`, `phpstan`, `psalm`, `rector`, `php-cs-fixer`, `phpcs`, `make lint`/`site-lint`/`cgl`/`phpstan`) covers every fast-check pattern observed in the fleet's CI workflows.

## What changes

| Layer | Before | After |
|---|---|---|
| `checkpoints.yaml` | `severity: info` | `severity: warning` |
| `references/maturity-levels.md` (L2 table) | "Info" | "Warning" |
| `references/maturity-levels.md` (checkpoint summary) | `Info` | `Warning` |

## Effect

A contributor who adds a fast-check CI step but forgets to mirror it locally — or a Renovate bump that drops a keyword reference — will now surface as a **warning** during `/assess agent-harness` instead of being buried in `info`-level noise. Stays below `error` severity so bootstrapping a new repo without a hook config doesn't block its first audit.

## Verification

- `yamllint -c .yamllint.yml skills/agent-harness/checkpoints.yaml` → clean
- `validate-skill.sh` → 0 errors
- AH-36 self-check against this repo → PASS (this skill's own `.pre-commit-config.yaml` references the keywords)