### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-harness",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Use when making a repo agent-ready, verifying harness consistency, checking for documentation drift, bootstrapping harness infrastructure (AGENTS.md as index, docs/ structure, CI verification, enforcement mechanisms), or auditing repo agent-readiness maturity level.",
   "repository": "https://github.com/netresearch/agent-harness-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires Bash, Read, Write, Edit, Glob, Grep tools"
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.3.0"
+  version: "1.4.0"
   repository: https://github.com/netresearch/agent-harness-skill
 allowed-tools: Bash(git:*,make:*,bash:*,wc:*,test:*,chmod:*) Read Write Edit Glob Grep Agent
 ---


### PR DESCRIPTION
Release **v1.4.0** (minor bump, conventional commits since v1.3.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.4.0.

Changes since v1.3.0:
- feat(harness): document CI/Hook Parity Principle, add AH-36 checkpoint, dogfood with lefthook.yml
- 
- The single most load-bearing rule across all 10 enforcement mechanisms:
- every fast deterministic check that runs in CI must also run as a
- pre-commit hook. CI is the slow, parallel, authoritative backstop —
- not the first feedback loop. When a contributor (human or agent)
- commits broken code and learns about it 90 seconds later from CI
- rather than 2 seconds earlier from a hook, the harness has a gap.
- 
- The corollary: when CI catches a mechanical issue a hook could have
- caught, the absence of the hook is the bug. Strengthen the harness
- rather than asking the operator to be more careful.
- 
- Changes:
- 
- - Add "CI / Hook Parity Principle" section to enforcement-mechanisms.md
-   covering: what qualifies as a fast check, stack-native framework
-   choice (captainhook/lefthook/husky/pre-commit), and the three common
-   failure patterns
- - AH-32 description updated in maturity-levels.md and checkpoints.yaml:

After merge: a signed tag `v1.4.0` on `main` triggers the release workflow.