### PR TITLE
feat(checkpoints): AH-40 — detect stale AGENTS.md after implementation changes

### DIFF
--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -152,16 +152,19 @@ mechanical:
 
 llm_reviews:
   - id: AH-40
-    name: AGENTS.md Architecture and Key Decisions reflect current implementation
+    desc: AGENTS.md Architecture and Key Decisions reflect current implementation
     type: llm_review
     severity: warning
     domain: documentation
     prompt: |
-      Read AGENTS.md — specifically the File Map, Architecture, and Key Decisions
-      sections (or equivalent). Then read the primary implementation files it references.
+      Read AGENTS.md (specifically the File Map and any references to docs/).
+      Then follow its references to architecture, decisions, and implementation files
+      (such as docs/ARCHITECTURE.md, docs/adr/, or similar).
+      Then read the primary implementation files referenced there.
 
-      Check for concrete contradictions between what AGENTS.md describes and what the
-      code actually does. Common failure modes after a significant implementation change:
+      Check for concrete contradictions between what AGENTS.md and its referenced
+      architecture docs describe and what the code actually does. Common failure modes
+      after a significant implementation change:
         - A tool, binary, or technique mentioned in Key Decisions that has been removed
           from the code (e.g. "uses splitsh-lite" but the script no longer downloads it)
         - An algorithm or step in the Architecture description that no longer matches
@@ -169,8 +172,8 @@ llm_reviews:
         - A file listed in the File Map that no longer exists or has a different purpose
 
       Do NOT flag style issues, naming conventions, or missing documentation for new
-      features (that is a separate concern). Only flag cases where AGENTS.md makes a
-      factually false claim about the current code.
+      features (that is a separate concern). Only flag cases where AGENTS.md or its
+      referenced docs make a factually false claim about the current code.
 
       Report: either a list of specific contradictions (AGENTS.md claim vs. actual code),
       or "No contradictions found."

--- a/skills/agent-harness/checkpoints.yaml
+++ b/skills/agent-harness/checkpoints.yaml
@@ -149,3 +149,29 @@ mechanical:
       || grep -rlE "$K" $H 2>/dev/null | head -1 | grep -q .
     severity: warning
     desc: "If CI runs a fast-check command, a hook config should reference at least one fast-check command too (best-effort CI/hook parity)"
+
+llm_reviews:
+  - id: AH-40
+    name: AGENTS.md Architecture and Key Decisions reflect current implementation
+    type: llm_review
+    severity: warning
+    domain: documentation
+    prompt: |
+      Read AGENTS.md — specifically the File Map, Architecture, and Key Decisions
+      sections (or equivalent). Then read the primary implementation files it references.
+
+      Check for concrete contradictions between what AGENTS.md describes and what the
+      code actually does. Common failure modes after a significant implementation change:
+        - A tool, binary, or technique mentioned in Key Decisions that has been removed
+          from the code (e.g. "uses splitsh-lite" but the script no longer downloads it)
+        - An algorithm or step in the Architecture description that no longer matches
+          the actual code flow
+        - A file listed in the File Map that no longer exists or has a different purpose
+
+      Do NOT flag style issues, naming conventions, or missing documentation for new
+      features (that is a separate concern). Only flag cases where AGENTS.md makes a
+      factually false claim about the current code.
+
+      Report: either a list of specific contradictions (AGENTS.md claim vs. actual code),
+      or "No contradictions found."
+    tags: [documentation, agents-md, accuracy, staleness]


### PR DESCRIPTION
## Motivation

During a session on the `elts-mirror` project, the entire split implementation was replaced (splitsh-lite → git orphan commits). After the change, `AGENTS.md` and `README.md` no longer accurately described what the code actually did — key decisions still referenced splitsh-lite even though it had been removed. No automated checkpoint caught this drift. The staleness was only discovered when the user manually asked "check if AGENTS.md is up to date" at the end of the session.

The existing `AH-01` only checks that `AGENTS.md` *exists*. There is no checkpoint that verifies the document's *content* reflects the current implementation.

## What AH-40 does

Adds a new `llm_reviews:` section to `checkpoints.yaml` with checkpoint **AH-40**. The checkpoint asks an LLM to:

1. Read `AGENTS.md` — specifically the File Map, Architecture, and Key Decisions sections (or equivalent).
2. Read the primary implementation files referenced there.
3. Report **concrete factual contradictions** — cases where AGENTS.md makes a claim that is demonstrably false given the current code.

Common failure modes it targets:
- A tool, binary, or technique mentioned in Key Decisions that has been removed from the code
- An algorithm or step in the Architecture description that no longer matches the actual code flow
- A file listed in the File Map that no longer exists or has a different purpose

## What AH-40 explicitly does NOT check

- Style issues or naming conventions
- Missing documentation for *newly added* features (that is a forward-coverage concern, not a staleness concern)
- Anchor targets, URL validity, or formatting

The scope is deliberately narrow: **only factually false claims about the current code**.

## Placement

The checkpoint is placed in a new top-level `llm_reviews:` section, separate from `mechanical:`, to make clear it requires LLM evaluation rather than a shell command.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)