### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-harness",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Use when making a repo agent-ready, verifying harness consistency, checking for documentation drift, bootstrapping harness infrastructure (AGENTS.md as index, docs/ structure, CI verification, enforcement mechanisms), or auditing repo agent-readiness maturity level.",
   "repository": "https://github.com/netresearch/agent-harness-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -18,13 +18,13 @@ The agent harness is repo-level infrastructure that makes repositories agent-rea
 
 ### 1. Verify (primary)
 
-Always start here. Run the verification script:
+Always start here. From the target repo root, run:
 
 ```bash
-scripts/verify-harness.sh /path/to/target-repo
+scripts/verify-harness.sh
 ```
 
-Analyse the output. Fix issues directly or suggest fixes to the user. Verification checks for dead references, line count limits, missing artefacts, and command/target alignment.
+Analyse the output. Fix issues directly or suggest fixes. Verification checks for dead references, line count limits, missing artefacts, and command/target alignment.
 
 ### 2. Bootstrap
 

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires Bash, Read, Write, Edit, Glob, Grep tools"
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.4.0"
+  version: "1.5.0"
   repository: https://github.com/netresearch/agent-harness-skill
 allowed-tools: Bash(git:*,make:*,bash:*,wc:*,test:*,chmod:*) Read Write Edit Glob Grep Agent
 ---
@@ -18,7 +18,7 @@ The agent harness is repo-level infrastructure that makes repositories agent-rea
 
 ### 1. Verify (primary)
 
-Always start here. Run the verification script against the target repo:
+Always start here. Run the verification script:
 
 ```bash
 scripts/verify-harness.sh /path/to/target-repo
@@ -31,7 +31,7 @@ Analyse the output. Fix issues directly or suggest fixes to the user. Verificati
 When artefacts are missing, create them from templates:
 
 | Artefact | Template | Platform |
-|---|---|---|
+| --- | --- | --- |
 | `AGENTS.md` | `templates/AGENTS.md.tmpl` | All |
 | `docs/ARCHITECTURE.md` | `templates/ARCHITECTURE.md.tmpl` | All |
 | `docs/exec-plans/{active,completed}/` | Create directories | All |


### PR DESCRIPTION
Release v1.5.0 (minor: new feature since v1.4.0).

Changes since v1.4.0:
- feat(checkpoints): AH-40 LLM review checkpoint detecting stale AGENTS.md after implementation changes (#33)
- chore(deps): workflow action pin updates (#34, #35)

Bump touches `.claude-plugin/plugin.json` and `skills/agent-harness/SKILL.md` (version), plus a markdownlint MD060 fix for the Bootstrap table delimiter row with a 4-word trim to stay under the 500-word SKILL.md cap.
