### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-harness",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Use when making a repo agent-ready, verifying harness consistency, checking for documentation drift, bootstrapping harness infrastructure (AGENTS.md as index, docs/ structure, CI verification, enforcement mechanisms), or auditing repo agent-readiness maturity level.",
   "repository": "https://github.com/netresearch/agent-harness-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-harness/SKILL.md
+++ b/skills/agent-harness/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires Bash, Read, Write, Edit, Glob, Grep tools"
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.5.0"
+  version: "1.6.0"
   repository: https://github.com/netresearch/agent-harness-skill
 allowed-tools: Bash(git:*,make:*,bash:*,wc:*,test:*,chmod:*) Read Write Edit Glob Grep Agent
 ---


### PR DESCRIPTION
Release v1.6.0.

Bumps plugin.json + skill metadata version 1.5.0 → 1.6.0.

Content since v1.5.0:
- feat(agent-harness): add Forgejo/Gitea platform support (#37)